### PR TITLE
Get environment var/config piped to change data source

### DIFF
--- a/src/dotnet/CarbonAware.Aggregators/src/Configuration/ServiceCollectionExtensions.cs
+++ b/src/dotnet/CarbonAware.Aggregators/src/Configuration/ServiceCollectionExtensions.cs
@@ -2,38 +2,18 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using CarbonAware.DataSources.Configuration;
 using CarbonAware.Aggregators.CarbonAware;
-
+using Microsoft.Extensions.Configuration;
 
 namespace CarbonAware.Aggregators.Configuration;
 
 public static class ServiceCollectionExtensions
 {
     /// <summary>
-    /// Service Extension that adds required services needed for pulling
-    /// information from data sources that provide Carbon Intensity data.
-    /// This method is aware of <see cref="EnvironmentVariables.CarbonIntensityDataSource"/>
-    /// how it is set based on the values of <see cref="DataSourceType"/>
-    /// For instance, setting "CARBON_INTENSITY_DATASOURCE=JSON" environment variable
-    /// it would pull Carbon Intensity data from the static json file.
-    /// If there "CARBON_INTENSITY_DATASOURCE" is not set or empty, it would default to JSON.
+    /// Add services needed in order to pull data from a Carbon Intensity data source.
     /// </summary>
-    /// 
-    public static void AddCarbonAwareEmissionServices(this IServiceCollection services)
+    public static void AddCarbonAwareEmissionServices(this IServiceCollection services, IConfiguration configuration)
     {
-        var dsrc = Environment.GetEnvironmentVariable(EnvironmentVariables.CarbonIntensityDataSource);
-        services.AddDataSourceService(GetDataSourceTypeFromValue(dsrc));
+        services.AddDataSourceService(configuration);
         services.TryAddSingleton<ICarbonAwareAggregator, CarbonAwareAggregator>();
-    }
-
-    private static DataSourceType GetDataSourceTypeFromValue(string? envValue)
-    {
-        DataSourceType result;
-        if (String.IsNullOrEmpty(envValue) ||
-            !Enum.TryParse<DataSourceType>(envValue, true, out result))
-        {
-            // defaults to JSON in case env is empty, null or parsing fails
-            return DataSourceType.JSON;
-        }
-        return result;
     }
 }

--- a/src/dotnet/CarbonAware.Aggregators/src/Configuration/ServiceCollectionExtensions.cs
+++ b/src/dotnet/CarbonAware.Aggregators/src/Configuration/ServiceCollectionExtensions.cs
@@ -8,6 +8,16 @@ namespace CarbonAware.Aggregators.Configuration;
 
 public static class ServiceCollectionExtensions
 {
+    /// <summary>
+    /// Service Extension that adds required services needed for pulling
+    /// information from data sources that provide Carbon Intensity data.
+    /// This method is aware of <see cref="EnvironmentVariables.CarbonIntensityDataSource"/>
+    /// how it is set based on the values of <see cref="DataSourceType"/>
+    /// For instance, setting "CARBON_INTENSITY_DATASOURCE=JSON" environment variable
+    /// it would pull Carbon Intensity data from the static json file.
+    /// If there "CARBON_INTENSITY_DATASOURCE" is not set or empty, it would default to JSON.
+    /// </summary>
+    /// 
     public static void AddCarbonAwareEmissionServices(this IServiceCollection services)
     {
         var dsrc = Environment.GetEnvironmentVariable(EnvironmentVariables.CarbonIntensityDataSource);

--- a/src/dotnet/CarbonAware.Aggregators/src/Configuration/ServiceCollectionExtensions.cs
+++ b/src/dotnet/CarbonAware.Aggregators/src/Configuration/ServiceCollectionExtensions.cs
@@ -3,13 +3,27 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using CarbonAware.DataSources.Configuration;
 using CarbonAware.Aggregators.CarbonAware;
 
+
 namespace CarbonAware.Aggregators.Configuration;
 
 public static class ServiceCollectionExtensions
 {
     public static void AddCarbonAwareEmissionServices(this IServiceCollection services)
     {
-        services.AddDataSourceService(DataSourceType.JSON);
+        var dsrc = Environment.GetEnvironmentVariable(EnvironmentVariables.CarbonIntensityDataSource);
+        services.AddDataSourceService(GetDataSourceTypeFromValue(dsrc));
         services.TryAddSingleton<ICarbonAwareAggregator, CarbonAwareAggregator>();
+    }
+
+    private static DataSourceType GetDataSourceTypeFromValue(string? envValue)
+    {
+        DataSourceType result;
+        if (String.IsNullOrEmpty(envValue) ||
+            !Enum.TryParse<DataSourceType>(envValue, true, out result))
+        {
+            // defaults to JSON in case env is empty, null or parsing fails
+            return DataSourceType.JSON;
+        }
+        return result;
     }
 }

--- a/src/dotnet/CarbonAware.Aggregators/test/CarbonAwareAggregatorTests.cs
+++ b/src/dotnet/CarbonAware.Aggregators/test/CarbonAwareAggregatorTests.cs
@@ -10,6 +10,7 @@ using NUnit.Framework;
 using Microsoft.Extensions.DependencyInjection;
 using CarbonAware.Aggregators.Configuration;
 using CarbonAware.Interfaces;
+using Microsoft.Extensions.Configuration;
 
 namespace CarbonAware.Aggregators.Tests;
 
@@ -47,7 +48,7 @@ public class CarbonAwareAggregatorTests
     {
         var serviceCollection = new ServiceCollection();
         serviceCollection.AddLogging(); 
-        serviceCollection.AddCarbonAwareEmissionServices();
+        serviceCollection.AddCarbonAwareEmissionServices(It.IsAny<IConfiguration>());
         var serviceProvider = serviceCollection.BuildServiceProvider();
         var aggregator = serviceProvider.GetRequiredService<ICarbonAwareAggregator>();
         Assert.NotNull(aggregator);

--- a/src/dotnet/CarbonAware.CLI/Program.cs
+++ b/src/dotnet/CarbonAware.CLI/Program.cs
@@ -21,8 +21,9 @@ class Program
                 .AddEnvironmentVariables();
         var config = configurationBuilder.Build();
         var services = new ServiceCollection();
+        services.Configure<EnvironmentVariablesConfiguration>(config.GetSection(EnvironmentVariablesConfiguration.Key));
         services.AddSingleton<IConfiguration>(config);
-        services.AddCarbonAwareEmissionServices();
+        services.AddCarbonAwareEmissionServices(config);
 
         services.AddLogging();
         var serviceProvider = services.BuildServiceProvider();

--- a/src/dotnet/CarbonAware.CLI/Program.cs
+++ b/src/dotnet/CarbonAware.CLI/Program.cs
@@ -21,7 +21,7 @@ class Program
                 .AddEnvironmentVariables();
         var config = configurationBuilder.Build();
         var services = new ServiceCollection();
-        services.Configure<EnvironmentVariablesConfiguration>(config.GetSection(EnvironmentVariablesConfiguration.Key));
+        services.Configure<CarbonAwareVariablesConfiguration>(config.GetSection(CarbonAwareVariablesConfiguration.Key));
         services.AddSingleton<IConfiguration>(config);
         services.AddCarbonAwareEmissionServices(config);
 

--- a/src/dotnet/CarbonAware.DataSources.Registration/Configuration/ServiceCollectionExtensions.cs
+++ b/src/dotnet/CarbonAware.DataSources.Registration/Configuration/ServiceCollectionExtensions.cs
@@ -1,14 +1,18 @@
 using Microsoft.Extensions.DependencyInjection;
 using CarbonAware.DataSources.Json.Configuration;
 using CarbonAware.DataSources.WattTime.Configuration;
+using Microsoft.Extensions.Configuration;
 
 namespace CarbonAware.DataSources.Configuration;
 public static class ServiceCollectionExtensions
 {
-    public static void AddDataSourceService(this IServiceCollection services, DataSourceType dataSourceType)
+    public static void AddDataSourceService(this IServiceCollection services, IConfiguration configuration)
     {
         // find all the Classes in the Assembly that implements AddEmissionServices method,
         // and added them here with the specific implementation class.
+        var envVars = configuration?.GetSection(EnvironmentVariablesConfiguration.Key).Get<EnvironmentVariablesConfiguration>();
+        var dataSourceType = GetDataSourceTypeFromValue(envVars?.CarbonIntensityDataSource);
+
         switch (dataSourceType)
         {
             case DataSourceType.JSON:
@@ -23,8 +27,19 @@ public static class ServiceCollectionExtensions
             }
             case DataSourceType.None:
             {
-                throw new NotSupportedException("DataSource type not supported");
+                throw new NotSupportedException($"DataSourceType {dataSourceType.ToString()} not supported");
             }
         }
+    }
+    private static DataSourceType GetDataSourceTypeFromValue(string? srcVal)
+    {
+        DataSourceType result;
+        if (String.IsNullOrEmpty(srcVal) ||
+            !Enum.TryParse<DataSourceType>(srcVal, true, out result))
+        {
+            // defaults to JSON in case env is empty, null or parsing fails
+            return DataSourceType.JSON;
+        }
+        return result;
     }
 }

--- a/src/dotnet/CarbonAware.DataSources.Registration/Configuration/ServiceCollectionExtensions.cs
+++ b/src/dotnet/CarbonAware.DataSources.Registration/Configuration/ServiceCollectionExtensions.cs
@@ -10,7 +10,7 @@ public static class ServiceCollectionExtensions
     {
         // find all the Classes in the Assembly that implements AddEmissionServices method,
         // and added them here with the specific implementation class.
-        var envVars = configuration?.GetSection(EnvironmentVariablesConfiguration.Key).Get<EnvironmentVariablesConfiguration>();
+        var envVars = configuration?.GetSection(CarbonAwareVariablesConfiguration.Key).Get<CarbonAwareVariablesConfiguration>();
         var dataSourceType = GetDataSourceTypeFromValue(envVars?.CarbonIntensityDataSource);
 
         switch (dataSourceType)

--- a/src/dotnet/CarbonAware.DataSources.Registration/Configuration/ServiceCollectionExtensions.cs
+++ b/src/dotnet/CarbonAware.DataSources.Registration/Configuration/ServiceCollectionExtensions.cs
@@ -21,6 +21,10 @@ public static class ServiceCollectionExtensions
                     services.AddWattTimeDataSourceService();
                     break;
             }
+            case DataSourceType.None:
+            {
+                throw new NotSupportedException("DataSource type not supported");
+            }
         }
     }
 }

--- a/src/dotnet/CarbonAware.WebApi/Program.cs
+++ b/src/dotnet/CarbonAware.WebApi/Program.cs
@@ -9,7 +9,7 @@ builder.Services.AddControllers();
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
-builder.Services.Configure<EnvironmentVariablesConfiguration>(builder.Configuration.GetSection(EnvironmentVariablesConfiguration.Key));
+builder.Services.Configure<CarbonAwareVariablesConfiguration>(builder.Configuration.GetSection(CarbonAwareVariablesConfiguration.Key));
 builder.Services.AddCarbonAwareEmissionServices(builder.Configuration);
 
 var app = builder.Build();

--- a/src/dotnet/CarbonAware.WebApi/Program.cs
+++ b/src/dotnet/CarbonAware.WebApi/Program.cs
@@ -1,3 +1,4 @@
+using CarbonAware;
 using CarbonAware.Aggregators.Configuration;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -8,8 +9,8 @@ builder.Services.AddControllers();
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
-
-builder.Services.AddCarbonAwareEmissionServices();
+builder.Services.Configure<EnvironmentVariablesConfiguration>(builder.Configuration.GetSection(EnvironmentVariablesConfiguration.Key));
+builder.Services.AddCarbonAwareEmissionServices(builder.Configuration);
 
 var app = builder.Build();
 

--- a/src/dotnet/CarbonAware/CarbonAwareVariablesConfiguration.cs
+++ b/src/dotnet/CarbonAware/CarbonAwareVariablesConfiguration.cs
@@ -1,0 +1,10 @@
+namespace CarbonAware;
+
+/// <summary>
+/// Carbon Aware Variables bindings
+/// </summary>
+public class CarbonAwareVariablesConfiguration
+{
+    public const string Key = "CarbonAwareVars";
+    public string CarbonIntensityDataSource { get; set; }
+}

--- a/src/dotnet/CarbonAware/Constants.cs
+++ b/src/dotnet/CarbonAware/Constants.cs
@@ -13,10 +13,10 @@ public class Constants
 }
 
 /// <summary>
-/// Carbon Aware Environment variables bindings
+/// Carbon Aware Variables bindings
 /// </summary>
-public class EnvironmentVariablesConfiguration
+public class CarbonAwareVariablesConfiguration
 {
-    public const string Key = "EnvironmentVariables";
+    public const string Key = "CarbonAwareVars";
     public string CarbonIntensityDataSource { get; set; }
 }

--- a/src/dotnet/CarbonAware/Constants.cs
+++ b/src/dotnet/CarbonAware/Constants.cs
@@ -11,12 +11,3 @@ public class Constants
     public const string Duration = "duration";
     public const string Best = "best";
 }
-
-/// <summary>
-/// Carbon Aware Variables bindings
-/// </summary>
-public class CarbonAwareVariablesConfiguration
-{
-    public const string Key = "CarbonAwareVars";
-    public string CarbonIntensityDataSource { get; set; }
-}

--- a/src/dotnet/CarbonAware/Constants.cs
+++ b/src/dotnet/CarbonAware/Constants.cs
@@ -11,3 +11,8 @@ public class Constants
     public const string Duration = "duration";
     public const string Best = "best";
 }
+
+public class EnvironmentVariables
+{
+    public const string CarbonIntensityDataSource = "CARBON_INTENSITY_DATASOURCE";
+}

--- a/src/dotnet/CarbonAware/Constants.cs
+++ b/src/dotnet/CarbonAware/Constants.cs
@@ -12,7 +12,11 @@ public class Constants
     public const string Best = "best";
 }
 
-public class EnvironmentVariables
+/// <summary>
+/// Carbon Aware Environment variables bindings
+/// </summary>
+public class EnvironmentVariablesConfiguration
 {
-    public const string CarbonIntensityDataSource = "CARBON_INTENSITY_DATASOURCE";
+    public const string Key = "EnvironmentVariables";
+    public string CarbonIntensityDataSource { get; set; }
 }


### PR DESCRIPTION
Issue Number: User's story 205 - Task 258

## Summary
Add configurable properties for setting CA datasource (i.e JSON, WattTime)

## Changes

- Be able to switch using for configurable variables (i.e a env var) CarbonAware datasource 
export CarbonAwareVars__CarbonIntensityDataSource=json
export CarbonAwareVars__CarbonIntensityDataSource=watttime

## Checklist

- [x] Local Tests Passing?
- [x] CICD and Pipeline Tests Passing?
- [x] Added any new Tests?
- [x] Documentation Updates Made?
- [x] This is not a breaking change. If it is, please describe it below.

## Is this a breaking change?
If yes, what workflow does this break? 

## Anything else?
Other comments, collaborators, etc.
This PR Closes Issue #
