### PR TITLE
Updates to fully wire up WattTime

### DIFF
--- a/src/dotnet/CarbonAware.DataSources.Registration/Configuration/ServiceCollectionExtensions.cs
+++ b/src/dotnet/CarbonAware.DataSources.Registration/Configuration/ServiceCollectionExtensions.cs
@@ -22,7 +22,7 @@ public static class ServiceCollectionExtensions
             }
             case DataSourceType.WattTime:
             {
-                    services.AddWattTimeDataSourceService();
+                    services.AddWattTimeDataSourceService(configuration);
                     break;
             }
             case DataSourceType.None:

--- a/src/dotnet/CarbonAware.DataSources.WattTime/src/Configuration/ServiceCollectionExtensions.cs
+++ b/src/dotnet/CarbonAware.DataSources.WattTime/src/Configuration/ServiceCollectionExtensions.cs
@@ -9,11 +9,13 @@ namespace CarbonAware.DataSources.WattTime.Configuration;
 
 public static class ServiceCollectionExtensions
 {
-    public static void AddWattTimeDataSourceService(this IServiceCollection services)
+    public static void AddWattTimeDataSourceService(this IServiceCollection services, IConfiguration? configuration)
     {
-        var configurationBuilder = new ConfigurationBuilder();
-        var config = configurationBuilder.Build();
-        services.ConfigureWattTimeClient(config);
+        if(configuration == null)
+        {
+            throw new ConfigurationException("WattTime configuration required.");
+        }
+        services.ConfigureWattTimeClient(configuration);
         services.TryAddSingleton<ICarbonIntensityDataSource, WattTimeDataSource>();
         services.TryAddSingleton<ILocationSource, AzureLocationSource>();
     }

--- a/src/dotnet/CarbonAware.DataSources.WattTime/src/Configuration/ServiceCollectionExtensions.cs
+++ b/src/dotnet/CarbonAware.DataSources.WattTime/src/Configuration/ServiceCollectionExtensions.cs
@@ -11,10 +11,7 @@ public static class ServiceCollectionExtensions
 {
     public static void AddWattTimeDataSourceService(this IServiceCollection services, IConfiguration? configuration)
     {
-        if(configuration == null)
-        {
-            throw new ConfigurationException("WattTime configuration required.");
-        }
+        _ = configuration ?? throw new ConfigurationException("WattTime configuration required.");
         services.ConfigureWattTimeClient(configuration);
         services.TryAddSingleton<ICarbonIntensityDataSource, WattTimeDataSource>();
         services.TryAddSingleton<ILocationSource, AzureLocationSource>();

--- a/src/dotnet/CarbonAware.WebApi/Controllers/CarbonAwareController.cs
+++ b/src/dotnet/CarbonAware.WebApi/Controllers/CarbonAwareController.cs
@@ -46,7 +46,7 @@ public class CarbonAwareController : ControllerBase
     [HttpGet("bylocations")]
     public async Task<IActionResult> GetEmissionsDataForLocationsByTime([FromQuery(Name = "locations")] string[] locations, DateTime? time = null, DateTime? toTime = null, int durationMinutes = 0)
     {
-        IEnumerable<Location> locationEnumerable = locations.Select(loc => new Location(){ RegionName = loc });
+        IEnumerable<Location> locationEnumerable = locations.Select(loc => new Location(){ RegionName = loc, LocationType=LocationType.CloudProvider });
         var props = new Dictionary<string, object?>() {
             { CarbonAwareConstants.Locations, locationEnumerable },
             { CarbonAwareConstants.Start, time },
@@ -64,7 +64,7 @@ public class CarbonAwareController : ControllerBase
     [HttpGet("bylocation")]
     public async Task<IActionResult> GetEmissionsDataForLocationByTime(string location, DateTime? time = null, DateTime? toTime = null, int durationMinutes = 0)
     {;
-        var locations = new List<Location>() { new Location() { RegionName = location } };
+        var locations = new List<Location>() { new Location() { RegionName = location, LocationType=LocationType.CloudProvider } };
         var props = new Dictionary<string, object?>() {
             { CarbonAwareConstants.Locations, locations },
             { CarbonAwareConstants.Start, time },


### PR DESCRIPTION
Issue Number: 205

## Summary
Follow-on fixes to fully wire up WattTime

## Changes

- Add `LocationType` to all emissions controller endpoint locations
- Plumb `configuration` through when WattTime is the selected datasource

## Checklist

- [x] Local Tests Passing?
- [x] CICD and Pipeline Tests Passing?
- [ ] Added any new Tests?
- [ ] Documentation Updates Made?
- [ ] This is not a breaking change. If it is, please describe it below.

## Is this a breaking change?
If yes, what workflow does this break? 

## Anything else?
Other comments, collaborators, etc.
CC @pritipath 