### PR TITLE
Enabling code coverage + enabling additional analyzers

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk
+FROM mcr.microsoft.com/dotnet/sdk:6.0
 
 RUN apt-get update
 

--- a/.github/codecov.yaml
+++ b/.github/codecov.yaml
@@ -1,0 +1,20 @@
+codecov:
+  require_ci_to_pass: no
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: no
+      macro: no
+
+comment:
+  layout: "reach,diff,flags,files"
+  behavior: default
+  require_changes: no

--- a/.github/workflows/build-webapi.yaml
+++ b/.github/workflows/build-webapi.yaml
@@ -40,9 +40,7 @@ jobs:
         uses: dotnet/code-analysis@v1
         id: code-analysis
         with:
-          solution: ${{ env.DOTNET_SRC_DIR }}/CarbonAwareSDK.sln
-          build-breaking: false
-          all-categories: all
+          build-breaking: true
 
   container-unit-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-webapi.yaml
+++ b/.github/workflows/build-webapi.yaml
@@ -17,6 +17,8 @@ env:
 jobs:
   container-dotnet-build:
     runs-on: ubuntu-latest
+    env:
+      working-directory: ./src/dotnet
     container:
       image: mcr.microsoft.com/dotnet/sdk
     steps:
@@ -28,10 +30,13 @@ jobs:
           include-prerelease: false
       - name: Install dependencies
         run: dotnet restore
+        working-directory: ${{env:working-directory}}
       - name: Build
         run: dotnet build --configuration Release --no-restore
+        working-directory: ${{env:working-directory}}
       - name: Test
         run: dotnet test --no-restore --verbosity normal
+        working-directory: ${{env:working-directory}}
 
   container-unit-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-webapi.yaml
+++ b/.github/workflows/build-webapi.yaml
@@ -29,13 +29,13 @@ jobs:
           include-prerelease: false
       - name: Install dependencies
         run: dotnet restore
-        working-directory: ${DOTNET_SRC_DIR}
+        working-directory: ${{ env.DOTNET_SRC_DIR }}
       - name: Build
         run: dotnet build --configuration Release --no-restore
-        working-directory: ${DOTNET_SRC_DIR}
+        working-directory: ${{ env.DOTNET_SRC_DIR }}
       - name: Test
         run: dotnet test --no-restore --verbosity normal
-        working-directory: ${DOTNET_SRC_DIR}
+        working-directory: ${{ env.DOTNET_SRC_DIR }}
 
   container-unit-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-webapi.yaml
+++ b/.github/workflows/build-webapi.yaml
@@ -33,9 +33,11 @@ jobs:
       - name: Build
         run: dotnet build --configuration Release --no-restore
         working-directory: ${{ env.DOTNET_SRC_DIR }}
-      - name: Test
-        run: dotnet test --no-restore --verbosity normal
+      - name: Test + Code Coverage
+        run: dotnet test --no-restore --verbosity normal /p:CollectCoverage=true /p:CoverletOutputFormat=opencover
         working-directory: ${{ env.DOTNET_SRC_DIR }}
+      - name: Codecov
+        uses: codecov/codecov-action@v1
 
   container-unit-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-webapi.yaml
+++ b/.github/workflows/build-webapi.yaml
@@ -36,6 +36,13 @@ jobs:
       - name: Test
         run: dotnet test --no-restore --verbosity normal
         working-directory: ${{ env.DOTNET_SRC_DIR }}
+      - name: Run .NET Code Analysis
+        uses: dotnet/code-analysis@v1
+        id: code-analysis
+        with:
+          solution: ${{ env.DOTNET_SRC_DIR }}/CarbonAwareSDK.sln
+          build-breaking: false
+          all-categories: all
 
   container-unit-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-webapi.yaml
+++ b/.github/workflows/build-webapi.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup .NET Core SDK 6
         uses: actions/setup-dotnet@v2
         with:
-          dotnet-version: 6
+          dotnet-version: 6.0
       - name: Install dependencies
         run: dotnet restore
       - name: Build

--- a/.github/workflows/build-webapi.yaml
+++ b/.github/workflows/build-webapi.yaml
@@ -24,7 +24,8 @@ jobs:
       - name: Setup .NET Core SDK 6
         uses: actions/setup-dotnet@v2
         with:
-          dotnet-version: 6.0
+          dotnet-version: '6.0.x'
+          include-prerelease: false
       - name: Install dependencies
         run: dotnet restore
       - name: Build

--- a/.github/workflows/build-webapi.yaml
+++ b/.github/workflows/build-webapi.yaml
@@ -39,20 +39,6 @@ jobs:
       - name: Codecov
         uses: codecov/codecov-action@v1
 
-  container-unit-test:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repository
-      uses: actions/checkout@v2
-    
-    - name: Docker Target Build
-      run: docker build --target=build . -f ${DOCKERFILE_PATH} -t ca-api-build
-      working-directory: ./src/dotnet
-
-    - name: Docker Unit Test
-      run: docker run -w //src/ ca-api-build dotnet test
-      working-directory: ./src/dotnet
-
   container-validation:
       runs-on: ubuntu-latest
       steps:

--- a/.github/workflows/build-webapi.yaml
+++ b/.github/workflows/build-webapi.yaml
@@ -13,12 +13,11 @@ env:
   DOCKERFILE_PATH: "CarbonAware.WebApi/Dockerfile"
   HEALTH_ENDPOINT: "0.0.0.0:8080/health"
   DATA_ENDPOINT: "0.0.0.0:8080/emissions/bylocation?location=eastus"
+  DOTNET_SRC_DIR: "./src/dotnet"
 
 jobs:
   container-dotnet-build:
     runs-on: ubuntu-latest
-    env:
-      working-directory: ./src/dotnet
     container:
       image: mcr.microsoft.com/dotnet/sdk
     steps:
@@ -30,13 +29,13 @@ jobs:
           include-prerelease: false
       - name: Install dependencies
         run: dotnet restore
-        working-directory: ${{env:working-directory}}
+        working-directory: ${{env:DOTNET_SRC_DIR}}
       - name: Build
         run: dotnet build --configuration Release --no-restore
-        working-directory: ${{env:working-directory}}
+        working-directory: ${{env:DOTNET_SRC_DIR}}
       - name: Test
         run: dotnet test --no-restore --verbosity normal
-        working-directory: ${{env:working-directory}}
+        working-directory: ${{env:DOTNET_SRC_DIR}}
 
   container-unit-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-webapi.yaml
+++ b/.github/workflows/build-webapi.yaml
@@ -15,6 +15,23 @@ env:
   DATA_ENDPOINT: "0.0.0.0:8080/emissions/bylocation?location=eastus"
 
 jobs:
+  container-dotnet-build:
+    runs-on: ubuntu-latest
+    container:
+      image: mcr.microsoft.com/dotnet/sdk
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup .NET Core SDK 6
+        uses: actions/setup-dotnet@v2
+        with:
+          dotnet-version: 6
+      - name: Install dependencies
+        run: dotnet restore
+      - name: Build
+        run: dotnet build --configuration Release --no-restore
+      - name: Test
+        run: dotnet test --no-restore --verbosity normal
+
   container-unit-test:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build-webapi.yaml
+++ b/.github/workflows/build-webapi.yaml
@@ -36,6 +36,16 @@ jobs:
       - name: Test
         run: dotnet test --no-restore --verbosity normal
         working-directory: ${{ env.DOTNET_SRC_DIR }}
+
+  dotnet-codeanalysis:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup .NET Core SDK 6
+        uses: actions/setup-dotnet@v2
+        with:
+          dotnet-version: '6.0.x'
+          include-prerelease: false
       - name: Run .NET Code Analysis
         uses: dotnet/code-analysis@v1
         id: code-analysis

--- a/.github/workflows/build-webapi.yaml
+++ b/.github/workflows/build-webapi.yaml
@@ -29,13 +29,13 @@ jobs:
           include-prerelease: false
       - name: Install dependencies
         run: dotnet restore
-        working-directory: ${{env:DOTNET_SRC_DIR}}
+        working-directory: ${DOTNET_SRC_DIR}
       - name: Build
         run: dotnet build --configuration Release --no-restore
-        working-directory: ${{env:DOTNET_SRC_DIR}}
+        working-directory: ${DOTNET_SRC_DIR}
       - name: Test
         run: dotnet test --no-restore --verbosity normal
-        working-directory: ${{env:DOTNET_SRC_DIR}}
+        working-directory: ${DOTNET_SRC_DIR}
 
   container-unit-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-webapi.yaml
+++ b/.github/workflows/build-webapi.yaml
@@ -37,21 +37,6 @@ jobs:
         run: dotnet test --no-restore --verbosity normal
         working-directory: ${{ env.DOTNET_SRC_DIR }}
 
-  dotnet-codeanalysis:
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Setup .NET Core SDK 6
-        uses: actions/setup-dotnet@v2
-        with:
-          dotnet-version: '6.0.x'
-          include-prerelease: false
-      - name: Run .NET Code Analysis
-        uses: dotnet/code-analysis@v1
-        id: code-analysis
-        with:
-          build-breaking: true
-
   container-unit-test:
     runs-on: ubuntu-latest
     steps:

--- a/src/dotnet/CarbonAware.Aggregators/src/CarbonAware.Aggregators.csproj
+++ b/src/dotnet/CarbonAware.Aggregators/src/CarbonAware.Aggregators.csproj
@@ -10,6 +10,14 @@
     <ItemGroup>
 	    <ProjectReference Include="..\..\CarbonAware\CarbonAware.csproj" />
 	    <ProjectReference Include="..\..\CarbonAware.DataSources.Registration\CarbonAware.DataSources.Registration.csproj" />
+      <PackageReference Include="coverlet.collector" Version="3.1.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      </PackageReference>
+      <PackageReference Include="coverlet.msbuild" Version="3.1.2">
+        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        <PrivateAssets>all</PrivateAssets>
+      </PackageReference>
     </ItemGroup>
 
 </Project>

--- a/src/dotnet/CarbonAware.Aggregators/src/CarbonAware.Aggregators.csproj
+++ b/src/dotnet/CarbonAware.Aggregators/src/CarbonAware.Aggregators.csproj
@@ -10,14 +10,6 @@
     <ItemGroup>
 	    <ProjectReference Include="..\..\CarbonAware\CarbonAware.csproj" />
 	    <ProjectReference Include="..\..\CarbonAware.DataSources.Registration\CarbonAware.DataSources.Registration.csproj" />
-      <PackageReference Include="coverlet.collector" Version="3.1.2">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      </PackageReference>
-      <PackageReference Include="coverlet.msbuild" Version="3.1.2">
-        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        <PrivateAssets>all</PrivateAssets>
-      </PackageReference>
     </ItemGroup>
 
 </Project>

--- a/src/dotnet/CarbonAware.Aggregators/src/CarbonAware.Aggregators.csproj
+++ b/src/dotnet/CarbonAware.Aggregators/src/CarbonAware.Aggregators.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
   </PropertyGroup>
 
     <ItemGroup>

--- a/src/dotnet/CarbonAware.Aggregators/test/CarbonAware.Aggregator.Tests.csproj
+++ b/src/dotnet/CarbonAware.Aggregators/test/CarbonAware.Aggregator.Tests.csproj
@@ -12,7 +12,14 @@
     <PackageReference Include="Moq" Version="4.17.2" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
-    <PackageReference Include="coverlet.collector" Version="3.1.0" />
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.msbuild" Version="3.1.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/dotnet/CarbonAware.CLI.Tests/CarbonAware.CLI.Tests.csproj
+++ b/src/dotnet/CarbonAware.CLI.Tests/CarbonAware.CLI.Tests.csproj
@@ -12,7 +12,14 @@
     <PackageReference Include="Moq" Version="4.17.2" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
-    <PackageReference Include="coverlet.collector" Version="3.1.0" />
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.msbuild" Version="3.1.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/dotnet/CarbonAware.DataSources.Json.Tests/CarbonAware.DataSources.Json.Tests.csproj
+++ b/src/dotnet/CarbonAware.DataSources.Json.Tests/CarbonAware.DataSources.Json.Tests.csproj
@@ -12,7 +12,14 @@
     <PackageReference Include="Moq" Version="4.17.2" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
-    <PackageReference Include="coverlet.collector" Version="3.1.0" />
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.msbuild" Version="3.1.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/dotnet/CarbonAware.DataSources.Json/CarbonAware.DataSources.Json.csproj
+++ b/src/dotnet/CarbonAware.DataSources.Json/CarbonAware.DataSources.Json.csproj
@@ -8,6 +8,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/dotnet/CarbonAware.DataSources.Registration/CarbonAware.DataSources.Registration.csproj
+++ b/src/dotnet/CarbonAware.DataSources.Registration/CarbonAware.DataSources.Registration.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/dotnet/CarbonAware.DataSources.WattTime/src/CarbonAware.DataSources.WattTime.csproj
+++ b/src/dotnet/CarbonAware.DataSources.WattTime/src/CarbonAware.DataSources.WattTime.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/dotnet/CarbonAware.DataSources.WattTime/test/CarbonAware.DataSources.WattTime.Tests.csproj
+++ b/src/dotnet/CarbonAware.DataSources.WattTime/test/CarbonAware.DataSources.WattTime.Tests.csproj
@@ -12,7 +12,14 @@
     <PackageReference Include="Moq" Version="4.17.2" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
-    <PackageReference Include="coverlet.collector" Version="3.1.0" />
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.msbuild" Version="3.1.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/dotnet/CarbonAware.LocationSources.Azure/src/CarbonAware.LocationSources.Azure.csproj
+++ b/src/dotnet/CarbonAware.LocationSources.Azure/src/CarbonAware.LocationSources.Azure.csproj
@@ -8,6 +8,7 @@
 		<TargetFramework>net6.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
+		<EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/dotnet/CarbonAware.LocationSources.Azure/test/CarbonAware.LocationSources.Azure.Test.csproj
+++ b/src/dotnet/CarbonAware.LocationSources.Azure/test/CarbonAware.LocationSources.Azure.Test.csproj
@@ -11,7 +11,14 @@
 	  <PackageReference Include="Moq" Version="4.17.2" />
 	  <PackageReference Include="NUnit" Version="3.13.2" />
 	  <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
-	  <PackageReference Include="coverlet.collector" Version="3.1.0" />
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.msbuild" Version="3.1.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/dotnet/CarbonAware.Plugins.BasicJsonPlugin.Tests/CarbonAware.Plugins.BasicJsonPlugin.Tests.csproj
+++ b/src/dotnet/CarbonAware.Plugins.BasicJsonPlugin.Tests/CarbonAware.Plugins.BasicJsonPlugin.Tests.csproj
@@ -13,6 +13,14 @@
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.msbuild" Version="3.1.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/dotnet/CarbonAware.Plugins.BasicJsonPlugin/CarbonAware.Plugins.BasicJsonPlugin.csproj
+++ b/src/dotnet/CarbonAware.Plugins.BasicJsonPlugin/CarbonAware.Plugins.BasicJsonPlugin.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
-
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/dotnet/CarbonAware.Tests/CarbonAware.Tests.csproj
+++ b/src/dotnet/CarbonAware.Tests/CarbonAware.Tests.csproj
@@ -52,7 +52,14 @@
     <PackageReference Include="Moq" Version="4.17.2" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
-    <PackageReference Include="coverlet.collector" Version="3.1.0" />
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.msbuild" Version="3.1.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/dotnet/CarbonAware.Tools.WattTimeClient.Tests/CarbonAware.Tools.WattTimeClient.Tests.csproj
+++ b/src/dotnet/CarbonAware.Tools.WattTimeClient.Tests/CarbonAware.Tools.WattTimeClient.Tests.csproj
@@ -12,6 +12,10 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="coverlet.msbuild" Version="3.1.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="Moq" Version="4.17.2" />
     <PackageReference Include="NUnit" Version="3.13.3" />

--- a/src/dotnet/CarbonAware.Tools.WattTimeClient/CarbonAware.Tools.WattTimeClient.csproj
+++ b/src/dotnet/CarbonAware.Tools.WattTimeClient/CarbonAware.Tools.WattTimeClient.csproj
@@ -27,5 +27,13 @@
     <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Microsoft.Net.Http.Headers" Version="2.2.8" />
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.msbuild" Version="3.1.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 </Project>

--- a/src/dotnet/CarbonAware.Tools.WattTimeClient/CarbonAware.Tools.WattTimeClient.csproj
+++ b/src/dotnet/CarbonAware.Tools.WattTimeClient/CarbonAware.Tools.WattTimeClient.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/dotnet/CarbonAware.Tools.WattTimeClient/CarbonAware.Tools.WattTimeClient.csproj
+++ b/src/dotnet/CarbonAware.Tools.WattTimeClient/CarbonAware.Tools.WattTimeClient.csproj
@@ -27,13 +27,5 @@
     <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Microsoft.Net.Http.Headers" Version="2.2.8" />
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="coverlet.msbuild" Version="3.1.2">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
   </ItemGroup>
 </Project>

--- a/src/dotnet/CarbonAware.WebApi.Tests/unitTests/CarbonAware.WebApi.UnitTests.csproj
+++ b/src/dotnet/CarbonAware.WebApi.Tests/unitTests/CarbonAware.WebApi.UnitTests.csproj
@@ -11,6 +11,14 @@
 	<PackageReference Include="Moq" Version="4.17.2" />
 	<PackageReference Include="NUnit" Version="3.13.3" />
 	<PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+  <PackageReference Include="coverlet.collector" Version="3.1.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.msbuild" Version="3.1.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/dotnet/CarbonAware.WebApi/CarbonAware.WebApi.csproj
+++ b/src/dotnet/CarbonAware.WebApi/CarbonAware.WebApi.csproj
@@ -25,14 +25,6 @@
       <TreatAsUsed>true</TreatAsUsed>
     </PackageReference>
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="coverlet.msbuild" Version="3.1.2">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/dotnet/CarbonAware.WebApi/CarbonAware.WebApi.csproj
+++ b/src/dotnet/CarbonAware.WebApi/CarbonAware.WebApi.csproj
@@ -25,6 +25,14 @@
       <TreatAsUsed>true</TreatAsUsed>
     </PackageReference>
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.msbuild" Version="3.1.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/dotnet/CarbonAware.WebApi/CarbonAware.WebApi.csproj
+++ b/src/dotnet/CarbonAware.WebApi/CarbonAware.WebApi.csproj
@@ -6,6 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>8d822819-8a1f-45e4-95fb-d4a9c3a9439f</UserSecretsId>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/dotnet/CarbonAware/CarbonAware.csproj
+++ b/src/dotnet/CarbonAware/CarbonAware.csproj
@@ -3,7 +3,10 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
   </PropertyGroup>
+
+
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />

--- a/src/dotnet/CarbonAware/CarbonAware.csproj
+++ b/src/dotnet/CarbonAware/CarbonAware.csproj
@@ -6,8 +6,6 @@
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
   </PropertyGroup>
 
-
-
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />

--- a/src/dotnet/CarbonAware/CarbonAware.csproj
+++ b/src/dotnet/CarbonAware/CarbonAware.csproj
@@ -15,6 +15,14 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
     <PackageReference Include="System.ComponentModel.Composition" Version="6.0.0" />
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.msbuild" Version="3.1.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/src/dotnet/CarbonAware/CarbonAware.csproj
+++ b/src/dotnet/CarbonAware/CarbonAware.csproj
@@ -15,14 +15,6 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
     <PackageReference Include="System.ComponentModel.Composition" Version="6.0.0" />
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="coverlet.msbuild" Version="3.1.2">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Issue Number: 170, 283
[![codecov](https://codecov.io/gh/microsoft/carbon-aware-sdk/branch/geomat/workflow-updates/graph/badge.svg?token=JELSAGUCHB)](https://codecov.io/gh/microsoft/carbon-aware-sdk)

## Summary
Improving consistency between devcontainer build environment and pipeline build environment. Turning on additional analysis rules.

## Changes

- Pins devcontainer version to 6
- Adds new job in CI pipeline to build dotnet app in the devcontainer making it easier to migrate from including the full SDK in the actual app container (at some future point in time)
- Turns on code coverage for high-impact libraries and packages.

## Checklist

- [x] Local Tests Passing?
- [x] CICD and Pipeline Tests Passing?
- [x] Added any new Tests?
- [x] Documentation Updates Made?
- [x] This is not a breaking change. If it is, please describe it below.

## Is this a breaking change?
Really shouldn't break anything 🤞

## Anything else?
Note that if you own / have worked on a library that doesn't have code coverage turned on but want to turn it on, please ping me in the review and we can get it added.

