### PR TITLE
Average CI over forecast window 

### DIFF
--- a/src/CarbonAware.Aggregators/src/CarbonAware/CarbonAwareAggregator.cs
+++ b/src/CarbonAware.Aggregators/src/CarbonAware/CarbonAwareAggregator.cs
@@ -1,5 +1,6 @@
 using CarbonAware.Model;
 using CarbonAware.Interfaces;
+using CarbonAware.Extensions;
 using Microsoft.Extensions.Logging;
 using System.Collections;
 using System.Diagnostics;
@@ -42,6 +43,7 @@ public class CarbonAwareAggregator : ICarbonAwareAggregator
         {
             DateTimeOffset start = GetOffsetOrDefault(props, CarbonAwareConstants.Start, DateTimeOffset.Now);
             DateTimeOffset end = GetOffsetOrDefault(props, CarbonAwareConstants.End,  start.AddDays(1));
+            TimeSpan windowSize = GetDurationOrDefault(props);
             _logger.LogInformation("Aggregator getting carbon intensity forecast from data source");
 
             var forecasts = new List<EmissionsForecast>();
@@ -51,9 +53,11 @@ public class CarbonAwareAggregator : ICarbonAwareAggregator
                 forecast.StartTime = start;
                 forecast.EndTime = end;
                 forecast.ForecastData = FilterByDate(forecast.ForecastData, start, end);
+                forecast.ForecastData = forecast.ForecastData.RollingAverage(windowSize);
                 if(forecast.ForecastData.Any())
                 {
                     forecast.OptimalDataPoint = GetOptimalEmissions(forecast.ForecastData);
+                    forecast.WindowSize = forecast.ForecastData.First().Duration;
                 }
                 forecasts.Add(forecast);
             }
@@ -101,6 +105,15 @@ public class CarbonAwareAggregator : ICarbonAwareAggregator
         Exception ex = new ArgumentException("locations parameter must be provided and be non empty");
         _logger.LogError("argument exception", ex);
         throw ex;
+    }
+
+    private TimeSpan GetDurationOrDefault(IDictionary props, TimeSpan defaultValue = default)
+    {
+        if (props[CarbonAwareConstants.Duration] is int duration)
+        {
+            return TimeSpan.FromMinutes(duration);
+        }
+        return defaultValue;
     }
 
     public async Task<double> CalcEmissionsAverageAsync(IDictionary props)

--- a/src/CarbonAware.Aggregators/src/CarbonAware/CarbonAwareAggregator.cs
+++ b/src/CarbonAware.Aggregators/src/CarbonAware/CarbonAwareAggregator.cs
@@ -52,7 +52,7 @@ public class CarbonAwareAggregator : ICarbonAwareAggregator
                 var forecast = await this._dataSource.GetCurrentCarbonIntensityForecastAsync(location);
                 forecast.StartTime = start;
                 forecast.EndTime = end;
-                forecast.ForecastData = FilterByDate(forecast.ForecastData, start, end);
+                forecast.ForecastData = IntervalHelper.FilterByDuration(forecast.ForecastData, start, end);
                 forecast.ForecastData = forecast.ForecastData.RollingAverage(windowSize);
                 if(forecast.ForecastData.Any())
                 {
@@ -66,10 +66,6 @@ public class CarbonAwareAggregator : ICarbonAwareAggregator
         }
     }
 
-    private IEnumerable<EmissionsData> FilterByDate(IEnumerable<EmissionsData> data, DateTimeOffset start, DateTimeOffset end)
-    {
-        return data.Where(ed => ed.Time >= start && ed.Time < end);
-    }
     private EmissionsData GetOptimalEmissions(IEnumerable<EmissionsData> emissionsData)
     {
         return emissionsData.Aggregate((minData, nextData) => minData.Rating < nextData.Rating ? minData : nextData);

--- a/src/CarbonAware.Aggregators/test/TestData.cs
+++ b/src/CarbonAware.Aggregators/test/TestData.cs
@@ -46,30 +46,35 @@ public static class TestData
         };
     }
 
-    public static EmissionsForecast GetForecast(int duration = 5)
+    public static EmissionsForecast GetForecast(int durationMinutes = 5)
     {
         var startTime = DateTimeOffset.Parse("2022-01-01T00:00:00Z");
+        var duration = TimeSpan.FromMinutes(durationMinutes);
         var forecastData = new List<EmissionsData>()
         {
             new EmissionsData {
                 Location = "westus",
                 Time = startTime,
-                Rating = 10
+                Rating = 10,
+                Duration = duration
             },
             new EmissionsData {
                 Location = "westus",
-                Time = startTime.AddMinutes(duration),
-                Rating = 20
+                Time = startTime.AddMinutes(durationMinutes),
+                Rating = 20,
+                Duration = duration
             },
             new EmissionsData {
                 Location = "westus",
-                Time = startTime.AddMinutes(duration*2),
-                Rating = 30
+                Time = startTime.AddMinutes(durationMinutes*2),
+                Rating = 30,
+                Duration = duration
             },
             new EmissionsData {
                 Location = "westus",
-                Time = startTime.AddMinutes(duration*3),
-                Rating = 40
+                Time = startTime.AddMinutes(durationMinutes*3),
+                Rating = 40,
+                Duration = duration
             }
         };
 

--- a/src/CarbonAware.DataSources/CarbonAware.DataSources.WattTime/test/WattTimeDataSourceTests.cs
+++ b/src/CarbonAware.DataSources/CarbonAware.DataSources.WattTime/test/WattTimeDataSourceTests.cs
@@ -127,6 +127,7 @@ public class WattTimeDataSourceTests
     [Test]
     public async Task GetCurrentCarbonIntensityForecastAsync_ReturnsResultsWhenRecordsFound()
     {
+        // Arrange
         var location = new Location() { RegionName = "eastus", LocationType = LocationType.CloudProvider, CloudProvider = CloudProvider.Azure };
         var balancingAuthority = new BalancingAuthority() { Abbreviation = "BA" };
         var generatedAt = new DateTimeOffset(2022, 4, 18, 12, 30, 00, TimeSpan.FromHours(-6));
@@ -134,6 +135,7 @@ public class WattTimeDataSourceTests
         var endDate = new DateTimeOffset(2022, 4, 18, 12, 33, 42, TimeSpan.FromHours(-6));
         var lbsPerMwhEmissions = 10;
         var gPerKwhEmissions = this.DataSource.ConvertMoerToGramsPerKilowattHour(lbsPerMwhEmissions);
+        var expectedDuration = TimeSpan.FromMinutes(5);
 
         var emissionData = new List<GridEmissionDataPoint>()
         {
@@ -142,7 +144,13 @@ public class WattTimeDataSourceTests
                 BalancingAuthorityAbbreviation = balancingAuthority.Abbreviation,
                 PointTime = startDate,
                 Value = lbsPerMwhEmissions,
-            }
+            },
+            new GridEmissionDataPoint()
+            {
+                BalancingAuthorityAbbreviation = balancingAuthority.Abbreviation,
+                PointTime = startDate + expectedDuration,
+                Value = lbsPerMwhEmissions,
+            },
         };
         var forecast = new Forecast(){
             GeneratedAt = generatedAt,
@@ -153,17 +161,28 @@ public class WattTimeDataSourceTests
             ).ReturnsAsync(() => forecast);
 
         SetupBalancingAuthority(balancingAuthority, location);
+
+        // Act
         var result = await this.DataSource.GetCurrentCarbonIntensityForecastAsync(location);
 
+        // Assert
         Assert.IsNotNull(result);
         Assert.AreEqual(generatedAt, result.GeneratedAt);
         Assert.AreEqual(location, result.Location);
 
-        var dataPoint = result.ForecastData.First();
-        Assert.IsNotNull(dataPoint);
-        Assert.AreEqual(gPerKwhEmissions, dataPoint.Rating);
-        Assert.AreEqual(balancingAuthority.Abbreviation, dataPoint.Location);
-        Assert.AreEqual(startDate, dataPoint.Time);
+        var firstDataPoint = result.ForecastData.First();
+        var lastDataPoint = result.ForecastData.Last();
+        Assert.IsNotNull(firstDataPoint);
+        Assert.AreEqual(gPerKwhEmissions, firstDataPoint.Rating);
+        Assert.AreEqual(balancingAuthority.Abbreviation, firstDataPoint.Location);
+        Assert.AreEqual(startDate, firstDataPoint.Time);
+        Assert.AreEqual(expectedDuration, firstDataPoint.Duration);
+
+        Assert.IsNotNull(lastDataPoint);
+        Assert.AreEqual(gPerKwhEmissions, lastDataPoint.Rating);
+        Assert.AreEqual(balancingAuthority.Abbreviation, lastDataPoint.Location);
+        Assert.AreEqual(startDate + expectedDuration, lastDataPoint.Time);
+        Assert.AreEqual(expectedDuration, lastDataPoint.Duration);
 
         this.LocationSource.Verify(r => r.ToGeopositionLocationAsync(location));
     }
@@ -184,6 +203,31 @@ public class WattTimeDataSourceTests
         var location = new Location() { RegionName = "eastus", LocationType = LocationType.CloudProvider, CloudProvider = CloudProvider.Azure };
         var balancingAuthority = new BalancingAuthority() { Abbreviation = "BA" };
         this.WattTimeClient.Setup(w => w.GetCurrentForecastAsync(balancingAuthority)).ThrowsAsync(new WattTimeClientException("No forecast"));
+
+        SetupBalancingAuthority(balancingAuthority, location);
+
+        Assert.ThrowsAsync<WattTimeClientException>(async () => await this.DataSource.GetCurrentCarbonIntensityForecastAsync(location));
+    }
+
+    [TestCase(0, TestName="No datapoints")]
+    [TestCase(1, TestName="1 datapoint")]
+    public void GetCurrentCarbonIntensityForecastAsync_ThrowsWhenTooFewDatapointsReturned(int numDataPoints)
+    {
+        // Arrange
+        var location = new Location() { RegionName = "eastus", LocationType = LocationType.CloudProvider, CloudProvider = CloudProvider.Azure };
+        var balancingAuthority = new BalancingAuthority() { Abbreviation = "BA" };
+        var emissionData = new List<GridEmissionDataPoint>();
+        for(var i=0; i<numDataPoints; i++)
+        {
+            emissionData.Add(new GridEmissionDataPoint());
+        }
+        var forecast = new Forecast(){
+            GeneratedAt = DateTimeOffset.Now,
+            ForecastData = emissionData
+        };
+
+        this.WattTimeClient.Setup(w => w.GetCurrentForecastAsync(balancingAuthority)
+            ).ReturnsAsync(() => forecast);
 
         SetupBalancingAuthority(balancingAuthority, location);
 

--- a/src/CarbonAware/src/Extensions/EmissionsDataExtensions.cs
+++ b/src/CarbonAware/src/Extensions/EmissionsDataExtensions.cs
@@ -1,0 +1,83 @@
+namespace CarbonAware.Extensions;
+
+public static class EmissionsDataExtensions
+{
+    public static IEnumerable<EmissionsData> RollingAverage(this IEnumerable<EmissionsData> data, TimeSpan windowSize = default, TimeSpan tickSize = default)
+    {
+        if(data.Count() == 0){ yield break; }
+
+        if(windowSize == default)
+        {
+           foreach(var d in data){ yield return d; }
+           yield break;
+        }
+
+        var q = new Queue<EmissionsData>();
+        var _data = data.GetEnumerator();
+        _data.MoveNext();
+        EmissionsData current = _data.Current;
+        EmissionsData last = null;
+
+        if(tickSize == default)
+        {
+            tickSize = (current.Duration > TimeSpan.Zero) ? current.Duration : throw new Exception("RollingAverage tickSize must be > 0");
+        }
+
+        // Set initial rolling average window
+        DateTimeOffset windowStartTime = current.Time;
+        DateTimeOffset windowEndTime = windowStartTime + windowSize;
+
+        while(current != null)
+        {
+            // Enqueue data points relevant to current rolling average window
+            while(current != null && windowEndTime > current.Time)
+            {
+                q.Enqueue(current);
+                last = current;
+                _data.MoveNext();
+                current = _data.Current;
+            }
+
+            // Calculate average for everything in the queue if we enqueued enough data points to cover the window
+            if(last != null && last.Time + last.Duration >= windowEndTime)
+            {
+                yield return AverageOverPeriod(q, windowStartTime, windowEndTime);
+            }
+
+            // Set bounds for the next window
+            windowStartTime = windowStartTime + tickSize;
+            windowEndTime = windowStartTime + windowSize;
+
+            // Dequeue items not needed for next window average
+            var peek = q.Peek();
+            while(peek != null && peek.Time + peek.Duration < windowStartTime)
+            {
+                q.Dequeue();
+                peek = q.Count == 0 ? null : q.Peek();
+            }
+        }
+    }
+
+    // TODO: Test this method outright when used as public method in the future.
+    private static EmissionsData AverageOverPeriod(this IEnumerable<EmissionsData> data, DateTimeOffset startTime, DateTimeOffset endTime)
+    {
+        EmissionsData newDataPoint = new EmissionsData()
+        {
+            Time = startTime,
+            Duration = (endTime - startTime),
+            Rating = 0.0,
+            Location = data.First().Location
+        };
+        foreach(var current in data)
+        {
+            if(current.Time + current.Duration > startTime && current.Time < endTime)
+            {
+                var lowerBound = (startTime >= current.Time) ? startTime : current.Time;
+                var upperBound = (endTime < current.Time + current.Duration) ? endTime : current.Time + current.Duration;
+                newDataPoint.Rating += current.Rating * (upperBound - lowerBound) / newDataPoint.Duration;
+            }
+        }
+
+        return newDataPoint;
+    }
+}

--- a/src/CarbonAware/test/extensions/EmissionsDataExtensionsTests.cs
+++ b/src/CarbonAware/test/extensions/EmissionsDataExtensionsTests.cs
@@ -1,0 +1,112 @@
+
+using CarbonAware.Model;
+using CarbonAware.Extensions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NUnit.Framework;
+
+
+namespace CarbonAware.Extensions.Tests;
+
+public class EmissionsDataExtensionsTests
+{
+    // Test class sets these fields in [SetUp] rather than traditional class constructor.
+    #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
+    private IEnumerable<EmissionsData> data;
+    private TimeSpan dataDuration;
+    private DateTimeOffset dataStartTime;
+    private string dataLocation;
+    #pragma warning restore CS8618
+
+    [SetUp]
+    public void Setup()
+    {
+        this.dataDuration =  TimeSpan.FromMinutes(5);
+        this.dataStartTime = new DateTimeOffset(2020, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        this.dataLocation = "A";
+        this.data = new List<EmissionsData>()
+        {
+            new EmissionsData() { Time = dataStartTime, Location = "A", Rating = 10.0, Duration = dataDuration },
+            new EmissionsData() { Time = dataStartTime + dataDuration, Location = "A", Rating = 20.0, Duration = dataDuration },
+            new EmissionsData() { Time = dataStartTime + dataDuration * 2, Location = "A", Rating = 30.0, Duration = dataDuration },
+            new EmissionsData() { Time = dataStartTime + dataDuration * 3, Location = "A", Rating = 40.0, Duration = dataDuration },
+        }; 
+    }
+
+
+    [TestCase(5, 5, new[] { 10.0, 20.0, 30.0, 40.0 }, TestName="window == data granularity, tick == data granularity")]
+    [TestCase(10, 5, new[] { 15.0, 25.0, 35.0 }, TestName="window > data granularity, tick == data granularity")]
+    [TestCase(2, 5, new[] { 10.0, 20.0, 30.0, 40.0 }, TestName="window < data granularity, tick == data granularity")]
+    [TestCase(5, 4, new[] { 10.0, 18.0, 26.0, 34.0 }, TestName="window == data granularity, tick < data granularity")]
+    [TestCase(10, 4, new[] { 15.0, 23.0, 31.0 }, TestName="window > data granularity, tick < data granularity")]
+    [TestCase(2, 4, new[] { 10.0, 15.0, 20.0, 30.0, 40.0 }, TestName="window < data granularity, tick < data granularity")]
+    [TestCase(5, 7, new[] { 10.0, 24.0, 38.0 }, TestName="window == data granularity, tick > data granularity")]
+    [TestCase(10, 7, new[] { 15.0, 29.0 }, TestName="window > data granularity, tick > data granularity")]
+    [TestCase(2, 7, new[] { 10.0, 20.0, 35.0 }, TestName="window < data granularity, tick > data granularity")]
+    public void RollingAverage_ReturnsExpectedAverages(int windowSize, int tickSize, double[] expectedRatings)
+    {
+        // Arrange
+        var expectedData = new List<EmissionsData>();
+        for(var i = 0; i < expectedRatings.Count(); i++)
+        {
+            expectedData.Add(new EmissionsData() { Time = this.dataStartTime + i * TimeSpan.FromMinutes(tickSize), Location = this.dataLocation, Rating = expectedRatings[i], Duration = TimeSpan.FromMinutes(windowSize) });
+        }
+
+        // Act
+        var result = this.data.RollingAverage(TimeSpan.FromMinutes(windowSize), TimeSpan.FromMinutes(tickSize));
+
+        // Assert
+        Assert.AreEqual(expectedData, result);
+    }
+
+    [TestCase(0, 5, 5, 5, new[] { 10.0, 20.0, 30.0, 40.0 }, TestName = "window == 0, tick == data granularity, returns original")]
+    [TestCase(0, 4, 5, 5, new[] { 10.0, 20.0, 30.0, 40.0 }, TestName = "window == 0, tick < data granularity, returns original")]
+    [TestCase(0, 7, 5, 5, new[] { 10.0, 20.0, 30.0, 40.0 }, TestName = "window == 0, tick > data granularity, returns original")]
+    [TestCase(5, 0, 5, 5, new[] { 10.0, 20.0, 30.0, 40.0 }, TestName = "window == data granularity, tick == 0, uses data granularity")]
+    [TestCase(10, 0, 10, 5, new[] { 15.0, 25.0, 35.0 }, TestName = "window > data granularity, tick == 0, uses data granularity")]
+    [TestCase(2, 0, 2, 5, new[] { 10.0, 20.0, 30.0, 40.0 }, TestName = "window < data granularity, tick == 0, uses data granularity")]
+    public void RollingAverage_ReturnsExpectedZeroCases(int windowSize, int tickSize, int expectedWindowSize, int expectedTickSize, double[] expectedRatings)
+    {
+        // Arrange
+        var expectedData = new List<EmissionsData>();
+        for (var i = 0; i < expectedRatings.Count(); i++)
+        {
+            expectedData.Add(new EmissionsData() { Time = this.dataStartTime + i * TimeSpan.FromMinutes(expectedTickSize), Location = this.dataLocation, Rating = expectedRatings[i], Duration = TimeSpan.FromMinutes(expectedWindowSize) });
+        }
+
+        // Act
+        var result = this.data.RollingAverage(TimeSpan.FromMinutes(windowSize), TimeSpan.FromMinutes(tickSize));
+
+        // Assert
+        Assert.AreEqual(expectedData, result);
+    }
+
+    [Test]
+    public void RollingAverage_EmptyListReturnsEmpty()
+    {
+        // Arrange
+        var emptyList = new List<EmissionsData>();
+
+        // Act
+        var result = emptyList.RollingAverage(TimeSpan.FromMinutes(5), TimeSpan.FromMinutes(5));
+
+        // Assert
+        Assert.AreEqual(Enumerable.Empty<EmissionsData>(), result);
+    }
+
+    [Test]
+    public void RollingAverage_ThrowsForZeroDurationData()
+    {
+        // Arrange
+        var zeroDurationData = new List<EmissionsData>()
+        {
+            new EmissionsData() { Duration = TimeSpan.Zero }
+        };
+
+        // Act
+        var result = zeroDurationData.RollingAverage(TimeSpan.FromMinutes(5));
+
+        // Assert
+        Assert.Throws<Exception>(() => result.ToList());
+    }
+}

--- a/src/CarbonAware/test/extensions/EmissionsDataExtensionsTests.cs
+++ b/src/CarbonAware/test/extensions/EmissionsDataExtensionsTests.cs
@@ -18,7 +18,7 @@ public class EmissionsDataExtensionsTests
     private string dataLocation;
     #pragma warning restore CS8618
 
-    [SetUp]
+    [OneTimeSetUp]
     public void Setup()
     {
         this.dataDuration =  TimeSpan.FromMinutes(5);


### PR DESCRIPTION
Issue Number: 201

## Summary
Adds averaging capabilities and integrates them into the forecasting endpoint.

## Details

This type of windowing is necessary for determining the optimal period to run any workload longer than the granularity of the prediction.  Take the following examples of values for 5 minute increments that produce unhelpful "optimal" answers:

`10, 20, 30, 40, 5` the optimal point is the last one, but if your workload is 10 minutes long you cannot start it at that point, you want the best 10 minute window.

`5, 55, 10, 10, 10` the optimal point is the first one, but for a 10min workload the average would 30, which is worse than starting at the middle point and getting a 10min average of 10.

Drastic shifts like that can show up in the data, but a more common error-case would be something gradual like `12, 11, 10, 12, 13` where starting at the `10` is less optimal than starting at the `11` for a 10min workload.

Rolling average windows are how we take into account the duration of the workload to find the optimal start time.  The same examples above transformed into 10min rolling windows are:

`15, 25, 35, 22.5` ,  `30, 32.5, 10, 10`, and `11.5, 10.5, 11, 12.5` making it easy to understand the impact of running a 10min workload at any of those points.

## Changes

- Adds `RollingAverage` capability to EmissionsData lists
- Calculates and adds duration to forecasting data points
- Refactors aggregator to use common date filter in place of custom one

## Checklist

- [x] Local Tests Passing?
- [x] CICD and Pipeline Tests Passing?
- [x] Added any new Tests?
- [x] This is not a breaking change. If it is, please describe it below.

## Anything else?

Managed commit history for "big PR impact" with that "small PR feel" ;)
