### PR TITLE
Handle reverse chronological time-series data

### DIFF
--- a/src/CarbonAware.WebApi/test/integrationTests/SciScoreControllerTests.cs
+++ b/src/CarbonAware.WebApi/test/integrationTests/SciScoreControllerTests.cs
@@ -22,11 +22,13 @@ public class SciScoreControllerTests : IntegrationTestingBase
 
 
     [TestCase("2022-1-1T04:05:06Z", "2022-1-2T04:05:06Z", "eastus", HttpStatusCode.OK)]
-    [TestCase("2021-1-1", "2022-1-2", "westus", HttpStatusCode.OK)]
-    public async Task SCI_AcceptsValidData_ReturnsContent(DateTimeOffset start, DateTimeOffset end, string location, HttpStatusCode expectedCode)
+    [TestCase("2021-11-18", "2022-1-2", "westus", HttpStatusCode.OK)]
+    public async Task SCI_AcceptsValidData_ReturnsContent(string start, string end, string location, HttpStatusCode expectedCode)
     {
-        _dataSourceMocker.SetupDataMock(start, end, location);
-        string timeInterval = start.ToUniversalTime().ToString("O") + "/" + end.ToUniversalTime().ToString("O");
+        var startTime = DateTimeOffset.Parse(start);
+        var endTime = DateTimeOffset.Parse(end);
+        _dataSourceMocker.SetupDataMock(startTime, endTime, location);
+        string timeInterval = $"{start}/{end}";
 
         object body = new
         {

--- a/src/CarbonAware.WebApi/test/integrationTests/mocks/WattTimeDataSourceMocker.cs
+++ b/src/CarbonAware.WebApi/test/integrationTests/mocks/WattTimeDataSourceMocker.cs
@@ -20,11 +20,29 @@ public class WattTimeDataSourceMocker : IDataSourceMocker
 
     public void SetupDataMock(DateTimeOffset start, DateTimeOffset end, string location)
     {
+        var data = new List<GridEmissionDataPoint>();
+        DateTimeOffset pointTime = start;
+        TimeSpan duration = TimeSpan.FromSeconds(300);
         GridEmissionDataPoint newDataPoint = WattTimeServerMocks.GetDefaultEmissionsDataPoint();
-        newDataPoint.PointTime = start;
+        newDataPoint.PointTime = pointTime;
         newDataPoint.BalancingAuthorityAbbreviation = location;
+        newDataPoint.Frequency = (int)duration.TotalSeconds;
 
-        WattTimeServerMocks.SetupDataMock(_server, new List<GridEmissionDataPoint> { newDataPoint });
+        data.Add(newDataPoint);
+        pointTime = newDataPoint.PointTime + duration;
+
+        while (pointTime < end)
+        {
+            newDataPoint = WattTimeServerMocks.GetDefaultEmissionsDataPoint();
+            newDataPoint.PointTime = pointTime;
+            newDataPoint.BalancingAuthorityAbbreviation = location;
+            newDataPoint.Frequency = (int)duration.TotalSeconds;
+
+            data.Add(newDataPoint);
+            pointTime = newDataPoint.PointTime + duration;
+        }
+
+        WattTimeServerMocks.SetupDataMock(_server, data);
     }
 
     public WebApplicationFactory<Program> OverrideWebAppFactory(WebApplicationFactory<Program> factory)


### PR DESCRIPTION
Issue Number: 401

## Summary
Update `AverageOverPeriod` to support reverse-chronological datasets.

## Changes

- Bug fix for chronological data
- Additional check for averaging periods not covered by dataset
- Additional unit tests

## Checklist

- [x] Local Tests Passing?
- [x] CICD and Pipeline Tests Passing?
- [x] Added any new Tests?
- [x] Documentation Updates Made? No
- [x] Are there any API Changes? No
- [x] This is not a breaking change.
