### PR TITLE
Reverting web api to use array of locations as input

### DIFF
--- a/src/CarbonAware.WebApi/src/Controllers/CarbonAwareController.cs
+++ b/src/CarbonAware.WebApi/src/Controllers/CarbonAwareController.cs
@@ -24,7 +24,7 @@ public class CarbonAwareController : ControllerBase
     /// <summary>
     /// Calculate the best emission data by location for a specified time period.
     /// </summary>
-    /// <param name="location"> String array of named locations.</param>
+    /// <param name="locations"> String array of named locations.</param>
     /// <param name="time"> [Optional] Start time for the data query.</param>
     /// <param name="toTime"> [Optional] End time for the data query.</param>
     /// <param name="durationMinutes"> [Optional] Duration for the data query.</param>
@@ -34,12 +34,12 @@ public class CarbonAwareController : ControllerBase
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(ValidationProblemDetails))]
     [HttpGet("bylocations/best")]
-    public async Task<IActionResult> GetBestEmissionsDataForLocationsByTime([FromQuery(Name = "location")] string[] location, DateTime? time = null, DateTime? toTime = null, int durationMinutes = 0)
+    public async Task<IActionResult> GetBestEmissionsDataForLocationsByTime([FromQuery(Name = "location")] string[] locations, DateTime? time = null, DateTime? toTime = null, int durationMinutes = 0)
     {
         using (var activity = Activity.StartActivity())
         {
             //The LocationType is hardcoded for now. Ideally this should be received from the request or configuration 
-            IEnumerable<Location> locationEnumerable = location.Select(loc => new Location() { RegionName = loc, LocationType = LocationType.CloudProvider });
+            IEnumerable<Location> locationEnumerable = locations.Select(location => new Location() { RegionName = location, LocationType = LocationType.CloudProvider });
             var props = new Dictionary<string, object?>() {
                 { CarbonAwareConstants.Locations, locationEnumerable },
                 { CarbonAwareConstants.Start, time},
@@ -59,7 +59,7 @@ public class CarbonAwareController : ControllerBase
     /// <summary>
     /// Calculate the observed emission data by list of locations for a specified time period.
     /// </summary>
-    /// <param name="location"> String array of named locations.</param>
+    /// <param name="locations"> String array of named locations.</param>
     /// <param name="time"> [Optional] Start time for the data query.</param>
     /// <param name="toTime"> [Optional] End time for the data query.</param>
     /// <param name="durationMinutes"> [Optional] Duration for the data query.</param>
@@ -69,11 +69,11 @@ public class CarbonAwareController : ControllerBase
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(ValidationProblemDetails))]
     [HttpGet("bylocations")]
-    public async Task<IActionResult> GetEmissionsDataForLocationsByTime([FromQuery(Name = "location")] string[] location, DateTime? time = null, DateTime? toTime = null, int durationMinutes = 0)
+    public async Task<IActionResult> GetEmissionsDataForLocationsByTime([FromQuery(Name = "location")] string[] locations, DateTime? time = null, DateTime? toTime = null, int durationMinutes = 0)
     {
         using (var activity = Activity.StartActivity())
         {
-            IEnumerable<Location> locationEnumerable = location.Select(loc => new Location(){ RegionName = loc, LocationType=LocationType.CloudProvider});
+            IEnumerable<Location> locationEnumerable = locations.Select(location => new Location(){ RegionName = location, LocationType=LocationType.CloudProvider});
             var props = new Dictionary<string, object?>() {
                 { CarbonAwareConstants.Locations, locationEnumerable },
                 { CarbonAwareConstants.Start, time },
@@ -117,7 +117,7 @@ public class CarbonAwareController : ControllerBase
     /// <summary>
     /// Maps user input query parameters to props dictionary for use with the data sources current forecast method.
     /// </summary>
-    /// <param name="location"> String array of named locations.</param>
+    /// <param name="locations"> String array of named locations.</param>
     /// <param name="startTime"> Start time of forecast period.</param>
     /// <param name="endTime"> End time of forecast period.</param>
     /// <param name="windowSize"> Size of rolling average window in minutes.</param>
@@ -128,11 +128,11 @@ public class CarbonAwareController : ControllerBase
     [ProducesResponseType(StatusCodes.Status500InternalServerError, Type = typeof(ValidationProblemDetails))]
     [ProducesResponseType(StatusCodes.Status501NotImplemented, Type = typeof(ValidationProblemDetails))]
     [HttpGet("forecasts/current")]
-    public async Task<IActionResult> GetCurrentForecastData([FromQuery(Name = "location")] string[] location, DateTimeOffset? startTime = null, DateTimeOffset? endTime = null, int? windowSize = null)
+    public async Task<IActionResult> GetCurrentForecastData([FromQuery(Name = "location")] string[] locations, DateTimeOffset? startTime = null, DateTimeOffset? endTime = null, int? windowSize = null)
     {
         using (var activity = Activity.StartActivity())
         {
-            IEnumerable<Location> locationEnumerable = location.Select(loc => new Location(){ RegionName = loc, LocationType=LocationType.CloudProvider});
+            IEnumerable<Location> locationEnumerable = locations.Select(location => new Location(){ RegionName = location, LocationType=LocationType.CloudProvider});
             var props = new Dictionary<string, object?>() {
                 { CarbonAwareConstants.Locations, locationEnumerable },
                 { CarbonAwareConstants.Start, startTime },

--- a/src/CarbonAware.WebApi/src/Controllers/CarbonAwareController.cs
+++ b/src/CarbonAware.WebApi/src/Controllers/CarbonAwareController.cs
@@ -24,19 +24,22 @@ public class CarbonAwareController : ControllerBase
     /// <summary>
     /// Calculate the best emission data by location for a specified time period.
     /// </summary>
+    /// <param name="location"> String array of named locations.</param>
+    /// <param name="time"> [Optional] Start time for the data query.</param>
+    /// <param name="toTime"> [Optional] End time for the data query.</param>
+    /// <param name="durationMinutes"> [Optional] Duration for the data query.</param>
     /// <returns>Array of EmissionsData objects that contains the location, time and the rating in g/kWh</returns>
     [Produces("application/json")]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(EmissionsData))]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(ValidationProblemDetails))]
     [HttpGet("bylocations/best")]
-    public async Task<IActionResult> GetBestEmissionsDataForLocationsByTime(string locations, DateTime? time = null, DateTime? toTime = null, int durationMinutes = 0)
+    public async Task<IActionResult> GetBestEmissionsDataForLocationsByTime([FromQuery(Name = "location")] string[] location, DateTime? time = null, DateTime? toTime = null, int durationMinutes = 0)
     {
         using (var activity = Activity.StartActivity())
         {
             //The LocationType is hardcoded for now. Ideally this should be received from the request or configuration 
-            var locationNames = locations.Split(',');
-            IEnumerable<Location> locationEnumerable = locationNames.Select(location => new Location() { RegionName = location, LocationType = LocationType.CloudProvider });
+            IEnumerable<Location> locationEnumerable = location.Select(loc => new Location() { RegionName = loc, LocationType = LocationType.CloudProvider });
             var props = new Dictionary<string, object?>() {
                 { CarbonAwareConstants.Locations, locationEnumerable },
                 { CarbonAwareConstants.Start, time},
@@ -56,18 +59,21 @@ public class CarbonAwareController : ControllerBase
     /// <summary>
     /// Calculate the observed emission data by list of locations for a specified time period.
     /// </summary>
+    /// <param name="location"> String array of named locations.</param>
+    /// <param name="time"> [Optional] Start time for the data query.</param>
+    /// <param name="toTime"> [Optional] End time for the data query.</param>
+    /// <param name="durationMinutes"> [Optional] Duration for the data query.</param>
     /// <returns>Array of EmissionsData objects that contains the location, time and the rating in g/kWh</returns>
     [Produces("application/json")]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<EmissionsData>))]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(ValidationProblemDetails))]
     [HttpGet("bylocations")]
-    public async Task<IActionResult> GetEmissionsDataForLocationsByTime(string locations, DateTime? time = null, DateTime? toTime = null, int durationMinutes = 0)
+    public async Task<IActionResult> GetEmissionsDataForLocationsByTime([FromQuery(Name = "location")] string[] location, DateTime? time = null, DateTime? toTime = null, int durationMinutes = 0)
     {
         using (var activity = Activity.StartActivity())
         {
-            var locationNames = locations.Split(',');
-            IEnumerable<Location> locationEnumerable = locationNames.Select(location => new Location(){ RegionName = location, LocationType=LocationType.CloudProvider});
+            IEnumerable<Location> locationEnumerable = location.Select(loc => new Location(){ RegionName = loc, LocationType=LocationType.CloudProvider});
             var props = new Dictionary<string, object?>() {
                 { CarbonAwareConstants.Locations, locationEnumerable },
                 { CarbonAwareConstants.Start, time },
@@ -82,6 +88,10 @@ public class CarbonAwareController : ControllerBase
     /// <summary>
     /// Calculate the best emission data by location for a specified time period.
     /// </summary>
+    /// <param name="location"> String named location.</param>
+    /// <param name="time"> [Optional] Start time for the data query.</param>
+    /// <param name="toTime"> [Optional] End time for the data query.</param>
+    /// <param name="durationMinutes"> [Optional] Duration for the data query.</param>
     /// <returns>Array of EmissionsData objects that contains the location, time and the rating in g/kWh</returns>
     [Produces("application/json")]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<EmissionsData>))]
@@ -107,7 +117,7 @@ public class CarbonAwareController : ControllerBase
     /// <summary>
     /// Maps user input query parameters to props dictionary for use with the data sources current forecast method.
     /// </summary>
-    /// <param name="locations"> Comma-separated string of named locations.</param>
+    /// <param name="location"> String array of named locations.</param>
     /// <param name="startTime"> Start time of forecast period.</param>
     /// <param name="endTime"> End time of forecast period.</param>
     /// <param name="windowSize"> Size of rolling average window in minutes.</param>
@@ -118,12 +128,11 @@ public class CarbonAwareController : ControllerBase
     [ProducesResponseType(StatusCodes.Status500InternalServerError, Type = typeof(ValidationProblemDetails))]
     [ProducesResponseType(StatusCodes.Status501NotImplemented, Type = typeof(ValidationProblemDetails))]
     [HttpGet("forecasts/current")]
-    public async Task<IActionResult> GetCurrentForecastData(string locations, DateTimeOffset? startTime = null, DateTimeOffset? endTime = null, int? windowSize = null)
+    public async Task<IActionResult> GetCurrentForecastData([FromQuery(Name = "location")] string[] location, DateTimeOffset? startTime = null, DateTimeOffset? endTime = null, int? windowSize = null)
     {
         using (var activity = Activity.StartActivity())
         {
-            var locationNames = locations.Split(',');
-            IEnumerable<Location> locationEnumerable = locationNames.Select(location => new Location(){ RegionName = location, LocationType=LocationType.CloudProvider});
+            IEnumerable<Location> locationEnumerable = location.Select(loc => new Location(){ RegionName = loc, LocationType=LocationType.CloudProvider});
             var props = new Dictionary<string, object?>() {
                 { CarbonAwareConstants.Locations, locationEnumerable },
                 { CarbonAwareConstants.Start, startTime },

--- a/src/CarbonAware.WebApi/src/README.md
+++ b/src/CarbonAware.WebApi/src/README.md
@@ -107,9 +107,9 @@ EG
 
 ### GET emissions/bylocations
 
-This endpoint calculates the observed emission data by list of locations for a specified time period
+This endpoint calculates the observed emission data by an array of locations for a specified time period
 
-Location is a required parameter and is name of the data region for the configured Cloud provider.
+Location is a required parameter and is an array of the names of the data region for the configured Cloud provider.
 If time period is not provided, it retrieves all the data until the current time.
 
 EG
@@ -131,9 +131,9 @@ EG
 
 ### GET emissions/bylocations/best
 
-This endpoint calculates the best observed emission data by list of locations for a specified time period
+This endpoint calculates the best observed emission data by an array of locations for a specified time period
 
-Location is a required parameter and is name of the data region for the configured Cloud provider.
+Location is a required parameter and is an array of the names of the data region for the configured Cloud provider.
 If time period is not provided, it retrieves all the data until the current time.
 
 EG

--- a/src/CarbonAware.WebApi/src/api.yaml
+++ b/src/CarbonAware.WebApi/src/api.yaml
@@ -31,10 +31,10 @@ paths:
     parameters:
     - name: locations
       in: query
-      description: 'Comma-separated list of names of the locations to be forecasted'
+      description: 'Array of names of the locations to be forecasted'
       required: true
       schema:
-        type: string
+        type: array
       example: eastus
     - name: windowSize
       in: query

--- a/src/CarbonAware.WebApi/test/integrationTests/IntegrationTestingBase.cs
+++ b/src/CarbonAware.WebApi/test/integrationTests/IntegrationTestingBase.cs
@@ -38,7 +38,7 @@ public abstract class IntegrationTestingBase
 
         //Add all query parameters
         var query = HttpUtility.ParseQueryString(builder.Query);
-        query["locations"] = location;
+        query["location"] = location;
         query["time"] = $"{start:O}";
         query["toTime"] = $"{end:O}";
 

--- a/src/CarbonAware.WebApi/test/unitTests/CarbonAwareControllerTests.cs
+++ b/src/CarbonAware.WebApi/test/unitTests/CarbonAwareControllerTests.cs
@@ -34,7 +34,7 @@ public class CarbonAwareControllerTests : TestsBase
         var controller = new CarbonAwareController(this.MockCarbonAwareLogger.Object, CreateAggregatorWithEmissionsData(data).Object);
 
         IActionResult ar1 = await controller.GetEmissionsDataForLocationByTime(location);
-        IActionResult ar2 = await controller.GetEmissionsDataForLocationsByTime(location);
+        IActionResult ar2 = await controller.GetEmissionsDataForLocationsByTime(new string[] { location });
 
         TestHelpers.AssertStatusCode(ar1, HttpStatusCode.OK);
         TestHelpers.AssertStatusCode(ar2, HttpStatusCode.OK);
@@ -57,7 +57,7 @@ public class CarbonAwareControllerTests : TestsBase
 
         var controller = new CarbonAwareController(this.MockCarbonAwareLogger.Object, CreateAggregatorWithBestEmissionsData(data).Object);
 
-        var ar = await controller.GetBestEmissionsDataForLocationsByTime(location);
+        var ar = await controller.GetBestEmissionsDataForLocationsByTime(new string[] { location });
 
         TestHelpers.AssertStatusCode(ar, HttpStatusCode.OK);
     }
@@ -81,7 +81,7 @@ public class CarbonAwareControllerTests : TestsBase
         var aggregator = CreateAggregatorWithForecastData(data);
         var controller = new CarbonAwareController(this.MockCarbonAwareLogger.Object, aggregator.Object);
 
-        IActionResult result = await controller.GetCurrentForecastData(location);
+        IActionResult result = await controller.GetCurrentForecastData(new string[] { location });
 
         TestHelpers.AssertStatusCode(result, HttpStatusCode.OK);
         aggregator.Verify(a => a.GetCurrentForecastDataAsync(It.IsAny<Dictionary<string, object>>()), Times.Once);
@@ -97,8 +97,8 @@ public class CarbonAwareControllerTests : TestsBase
 
         string location = "Sydney";
         IActionResult ar1 = await controller.GetEmissionsDataForLocationByTime(location);
-        IActionResult ar2 = await controller.GetBestEmissionsDataForLocationsByTime(location);
-        IActionResult ar3 = await controller.GetEmissionsDataForLocationsByTime(location);
+        IActionResult ar2 = await controller.GetBestEmissionsDataForLocationsByTime(new string[] { location });
+        IActionResult ar3 = await controller.GetEmissionsDataForLocationsByTime(new string[] { location });
 
         //Assert
         TestHelpers.AssertStatusCode(ar1, HttpStatusCode.NoContent);
@@ -114,8 +114,7 @@ public class CarbonAwareControllerTests : TestsBase
     {
         var controller = new CarbonAwareController(this.MockCarbonAwareLogger.Object, CreateAggregatorWithEmissionsData(new List<EmissionsData>()).Object);
 
-        string location = "Sydney";
-        IActionResult ar = await controller.GetBestEmissionsDataForLocationsByTime(location);
+        IActionResult ar = await controller.GetBestEmissionsDataForLocationsByTime(new string[] { "Sydney" });
 
         //Assert
         TestHelpers.AssertStatusCode(ar, HttpStatusCode.NoContent);


### PR DESCRIPTION
Issue Number: 394

## Summary
After researching alternate methods, for the sake of consistency and keeping the web api easy to understand by users and safe from possible bugs, we have decided to revert the controllers in the web api to take in the location as an array ala `locations=eastus&locations=westus`

## Changes

- List of comprehensive changes

## Checklist

- [X] Local Tests Passing?
- [X] CICD and Pipeline Tests Passing?
- [ ] Added any new Tests?
- [X] Documentation Updates Made?
- [X] Are there any API Changes? If yes, please describe below.
- [ ] This is not a breaking change. If it is, please describe it below.

## Are there API Changes?
Yes, the API is reverting to taking an array of locations as the parameter instead of a string that we parse

## Is this a breaking change?
If yes, what workflow does this break? 

## Anything else?
Other comments, collaborators, etc.
This PR Closes Issue #
