### PR TITLE
fix for bug 419 and 394 to require location-array

### DIFF
--- a/src/CarbonAware.WebApi/src/Controllers/CarbonAwareController.cs
+++ b/src/CarbonAware.WebApi/src/Controllers/CarbonAwareController.cs
@@ -34,7 +34,7 @@ public class CarbonAwareController : ControllerBase
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(ValidationProblemDetails))]
     [HttpGet("bylocations/best")]
-    public async Task<IActionResult> GetBestEmissionsDataForLocationsByTime([FromQuery(Name = "location")] string[] locations, DateTime? time = null, DateTime? toTime = null, int durationMinutes = 0)
+    public async Task<IActionResult> GetBestEmissionsDataForLocationsByTime([FromQuery(Name = "location"), BindRequired] string[] locations, DateTime? time = null, DateTime? toTime = null, int durationMinutes = 0)
     {
         using (var activity = Activity.StartActivity())
         {
@@ -69,7 +69,7 @@ public class CarbonAwareController : ControllerBase
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(ValidationProblemDetails))]
     [HttpGet("bylocations")]
-    public async Task<IActionResult> GetEmissionsDataForLocationsByTime([FromQuery(Name = "location")] string[] locations, DateTime? time = null, DateTime? toTime = null, int durationMinutes = 0)
+    public async Task<IActionResult> GetEmissionsDataForLocationsByTime([FromQuery(Name = "location"), BindRequired] string[] locations, DateTime? time = null, DateTime? toTime = null, int durationMinutes = 0)
     {
         using (var activity = Activity.StartActivity())
         {
@@ -128,7 +128,7 @@ public class CarbonAwareController : ControllerBase
     [ProducesResponseType(StatusCodes.Status500InternalServerError, Type = typeof(ValidationProblemDetails))]
     [ProducesResponseType(StatusCodes.Status501NotImplemented, Type = typeof(ValidationProblemDetails))]
     [HttpGet("forecasts/current")]
-    public async Task<IActionResult> GetCurrentForecastData([FromQuery(Name = "location")] string[] locations, DateTimeOffset? startTime = null, DateTimeOffset? endTime = null, int? windowSize = null)
+    public async Task<IActionResult> GetCurrentForecastData([FromQuery(Name = "location"), BindRequired] string[] locations, DateTimeOffset? startTime = null, DateTimeOffset? endTime = null, int? windowSize = null)
     {
         using (var activity = Activity.StartActivity())
         {

--- a/src/CarbonAware.WebApi/test/integrationTests/CarbonAwareControllerTests.cs
+++ b/src/CarbonAware.WebApi/test/integrationTests/CarbonAwareControllerTests.cs
@@ -60,4 +60,22 @@ public class CarbonAwareControllerTests : IntegrationTestingBase
         Assert.That(resultContent, Is.Not.Null);
         Assert.That(resultContent.Location, Is.EqualTo(location));
 ;    }
+
+
+    [TestCase("2022-1-1T04:05:06Z", "2022-1-2T04:05:06Z", null)]
+    public async Task MissingLocationInQuery_ReturnsBadRequest(DateTimeOffset start, DateTimeOffset end, string? location)
+    {
+        //Sets up any data endpoints needed for mocking purposes
+        _dataSourceMocker.SetupDataMock(start, end, location ?? "eastus");
+
+        //Call the private method to construct with parameters
+        var endpointURI = ConstructDateQueryURI(bestLocationsURI, location, start, end);
+
+        //Get response and response content
+        var result = await _client.GetAsync(endpointURI);
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest));
+        
+    }
 }

--- a/src/CarbonAware.WebApi/test/integrationTests/IntegrationTestingBase.cs
+++ b/src/CarbonAware.WebApi/test/integrationTests/IntegrationTestingBase.cs
@@ -31,16 +31,16 @@ public abstract class IntegrationTestingBase
     }
 
 
-    public string ConstructDateQueryURI(string Url, string location, DateTimeOffset start, DateTimeOffset end)
+    public string ConstructDateQueryURI(string Url, string? location, DateTimeOffset? start, DateTimeOffset? end)
     {
         // Use HTTP Query builder
         var builder = new UriBuilder();
 
         //Add all query parameters
         var query = HttpUtility.ParseQueryString(builder.Query);
-        query["location"] = location;
-        query["time"] = $"{start:O}";
-        query["toTime"] = $"{end:O}";
+        if (location != null) query["location"] = location;
+        if (start != null) query["time"] = $"{start:O}";
+        if (end != null) query["toTime"] = $"{end:O}";
 
         //Generate final query string
         builder.Query = query.ToString();


### PR DESCRIPTION
Issue Number: AzDO bugs 419 and 394

## Summary
Location-array was not being required

## Changes
Now location-array is required on API method

- The `location` string-array is now required for `bylocation/best`, `bylocation` and `forecasts/current` APIs

## Checklist

- [x] Local Tests Passing?
- [x] CICD and Pipeline Tests Passing?
- [ ] Added any new Tests?
- [ ] Documentation Updates Made?
- [x] Are there any API Changes? If yes, please describe below.
- [x] This is not a breaking change. If it is, please describe it below.

## Are there API Changes?
The change is that `location` string-array is now required for `bylocation/best`, `bylocation` and `forecasts/current` APIs

## Is this a breaking change?
Nope 

## Anything else?
Other comments, collaborators, etc.
This PR Closes Issue #
