### PR TITLE
Suppress error details for 500 in non-verbose mode

### DIFF
--- a/src/CarbonAware.WebApi/src/Filters/HttpResponseExceptionFilter.cs
+++ b/src/CarbonAware.WebApi/src/Filters/HttpResponseExceptionFilter.cs
@@ -46,12 +46,11 @@ public class HttpResponseExceptionFilter : IExceptionFilter
             }
             var isVerboseApi = _options.CurrentValue.VerboseApi;
        
-            if (statusCode == (int)HttpStatusCode.InternalServerError && isVerboseApi == false)
+            if (statusCode == (int)HttpStatusCode.InternalServerError && !isVerboseApi)
             {
                  response = new HttpValidationProblemDetails() {
                                 Title = HttpStatusCode.InternalServerError.ToString(),
                                 Status = statusCode,
-                                Detail = context.Exception.Message
                     };
             }
             else
@@ -61,7 +60,7 @@ public class HttpResponseExceptionFilter : IExceptionFilter
                             Status = statusCode,
                             Detail = context.Exception.Message
                 };
-                if (isVerboseApi == true) {
+                if (isVerboseApi) {
                     response.Errors["stackTrace"] = new string[] { context.Exception.StackTrace! };
                 }
             }

--- a/src/CarbonAware.WebApi/test/unitTests/HttpResponseExceptionFilterTests.cs
+++ b/src/CarbonAware.WebApi/test/unitTests/HttpResponseExceptionFilterTests.cs
@@ -149,7 +149,7 @@ public class HttpResponseExceptionFilterTests
         Assert.AreEqual((int)HttpStatusCode.InternalServerError, result!.StatusCode);
         Assert.AreEqual((int)HttpStatusCode.InternalServerError, content!.Status);
         Assert.AreEqual(HttpStatusCode.InternalServerError.ToString(), content.Title);
-        Assert.AreEqual("My validation error", content.Detail);
+        Assert.IsNull(content.Detail);
     }
 
     [Test]
@@ -213,7 +213,7 @@ public class HttpResponseExceptionFilterTests
         Assert.IsTrue(exceptionContext.ExceptionHandled);
         Assert.AreEqual((int)HttpStatusCode.InternalServerError, result!.StatusCode);
         Assert.AreEqual(HttpStatusCode.InternalServerError.ToString(), content!.Title);
-        Assert.AreEqual("My validation error", content.Detail);
+        Assert.IsNull(content.Detail);
     }
 
     private (ObjectResult?, HttpValidationProblemDetails?) GetExceptionContextDetails(ExceptionContext context)


### PR DESCRIPTION
Issue Number: fast-follow for #89 

## Summary
Removes details from non-verbose 500 errors

## Checklist

- [x] Local Tests Passing?
- [x] CICD and Pipeline Tests Passing?
- [x] Added any new Tests?
- [x] Documentation Updates Made?
- [x] Are there any API Changes? No
- [x] This is not a breaking change. No

