### PR TITLE
forecasting defaults and validation

### DIFF
--- a/src/CarbonAware.Aggregators/src/CarbonAware/CarbonAwareAggregator.cs
+++ b/src/CarbonAware.Aggregators/src/CarbonAware/CarbonAwareAggregator.cs
@@ -59,18 +59,7 @@ public class CarbonAwareAggregator : ICarbonAwareAggregator
                 var lastDataPoint = forecast.ForecastData.Last();
                 forecast.StartTime = GetOffsetOrDefault(props, CarbonAwareConstants.Start, firstDataPoint.Time);
                 forecast.EndTime = GetOffsetOrDefault(props, CarbonAwareConstants.End, lastDataPoint.Time + lastDataPoint.Duration);
-                if (forecast.StartTime < firstDataPoint.Time)
-                {
-                    throw new ArgumentException();
-                }
-                if (forecast.EndTime > lastDataPoint.Time + lastDataPoint.Duration)
-                {
-                    throw new ArgumentException();
-                }
-                if (forecast.StartTime >= forecast.EndTime)
-                {
-                    throw new ArgumentException();
-                }
+                forecast.Validate();
                 forecast.ForecastData = IntervalHelper.FilterByDuration(forecast.ForecastData, forecast.StartTime, forecast.EndTime);
                 forecast.ForecastData = forecast.ForecastData.RollingAverage(windowSize);
                 forecast.OptimalDataPoint = GetOptimalEmissions(forecast.ForecastData);

--- a/src/CarbonAware.Aggregators/src/CarbonAware/CarbonAwareAggregator.cs
+++ b/src/CarbonAware.Aggregators/src/CarbonAware/CarbonAwareAggregator.cs
@@ -48,8 +48,6 @@ public class CarbonAwareAggregator : ICarbonAwareAggregator
     {
         using (var activity = Activity.StartActivity())
         {
-            DateTimeOffset start = GetOffsetOrDefault(props, CarbonAwareConstants.Start, DateTimeOffset.MinValue);
-            DateTimeOffset end = GetOffsetOrDefault(props, CarbonAwareConstants.End, DateTimeOffset.MaxValue);
             TimeSpan windowSize = GetDurationOrDefault(props);
             _logger.LogInformation("Aggregator getting carbon intensity forecast from data source");
 
@@ -57,9 +55,11 @@ public class CarbonAwareAggregator : ICarbonAwareAggregator
             foreach(var location in GetLocationOrThrow(props))
             {
                 var forecast = await this._dataSource.GetCurrentCarbonIntensityForecastAsync(location);
-                forecast.StartTime = start;
-                forecast.EndTime = end;
-                forecast.ForecastData = IntervalHelper.FilterByDuration(forecast.ForecastData, start, end);
+                var firstDataPoint = forecast.ForecastData.First();
+                var lastDataPoint = forecast.ForecastData.Last();
+                forecast.StartTime = GetOffsetOrDefault(props, CarbonAwareConstants.Start, firstDataPoint.Time);
+                forecast.EndTime = GetOffsetOrDefault(props, CarbonAwareConstants.End, lastDataPoint.Time + lastDataPoint.Duration);
+                forecast.ForecastData = IntervalHelper.FilterByDuration(forecast.ForecastData, forecast.StartTime, forecast.EndTime);
                 forecast.ForecastData = forecast.ForecastData.RollingAverage(windowSize);
                 forecast.OptimalDataPoint = GetOptimalEmissions(forecast.ForecastData);
                 if(forecast.ForecastData.Any())

--- a/src/CarbonAware.Aggregators/test/CarbonAwareAggregatorTests.cs
+++ b/src/CarbonAware.Aggregators/test/CarbonAwareAggregatorTests.cs
@@ -79,26 +79,6 @@ public class CarbonAwareAggregatorTests
         Assert.IsEmpty(results);
     }
 
-    [TestCase("2022-01-14T23:55:00Z", null, TestName = "start before data")]
-    [TestCase(null, "2022-01-15T01:05:00Z", TestName = "end after data")]
-    [TestCase("2022-01-14T23:55:00Z", "2022-01-15T01:05:00Z", TestName = "start before & end after data")]
-    [TestCase("2022-01-15T00:45:00Z", "2022-01-15T00:30:00Z", TestName = "start & end within range, end before start")]
-    public void TestGetCurrentForecastDataAsync_InvalidDates_ThrowsException(string start, string end)
-    {
-        // Arrange
-        this.CarbonIntensityDataSource.Setup(x => x.GetCurrentCarbonIntensityForecastAsync(It.IsAny<Location>()))
-            .ReturnsAsync(TestData.GetForecast("2022-01-15T00:00:00Z", 15));
-
-        var props = new Dictionary<string, object>()
-        {
-            { CarbonAwareConstants.Locations, new List<Location>() { new Location() { RegionName = "westus" } } },
-        };
-        if (start != null) { props.Add(CarbonAwareConstants.Start, start); }
-        if (end != null) { props.Add(CarbonAwareConstants.End, end); }
-
-        Assert.ThrowsAsync<ArgumentException>(async () => await this.Aggregator.GetCurrentForecastDataAsync(props));
-    }
-
     [TestCase("2022-01-01T00:00:00Z", "2022-01-01T00:20:00Z", ExpectedResult = 4)] // Start and end time match
     [TestCase("2022-01-01T00:02:00Z", "2022-01-01T00:12:00Z", ExpectedResult = 3)] // Start time match and end midway through a datapoint
     public async Task<int> TestGetCurrentForecastDataAsync_FiltersDate(string start, string end)
@@ -205,11 +185,12 @@ public class CarbonAwareAggregatorTests
         Assert.AreEqual(expectedData, forecast.ForecastData);
     }
 
-    // TODO tests for starttime out of bounds end time out of bounds and endtime > start time
-    [TestCase("2022-12-31T00:00:00Z", "2022-01-01T00:20:00Z")] // Start Time out of bounds (lower than forecast start)
-    [TestCase("2022-01-01T00:00:00Z", "2022-01-01T00:30:00Z")] // End Time out of bounds (higher than forecast end) 
-    [TestCase("2022-01-01T00:20:00Z", "2022-01-01T00:00:00Z")] // End Time higher than start time
-    public Task TestGetCurrentForecastDataAsync_OutOfBoundsTimes_ReturnsBadRequest(string start, string end)
+    [TestCase("2021-12-31T00:00:00Z", "2022-01-01T00:20:00Z", TestName = "early startTime, valid endTime")]
+    [TestCase("2022-01-01T00:00:00Z", "2022-01-01T00:30:00Z", TestName = "valid startTime, late endTime")]
+    [TestCase("2021-12-31T00:00:00Z", null, TestName = "early startTime, default endTime")]
+    [TestCase(null, "2022-01-01T00:30:00Z", TestName = "default startTime, late endTime")]
+    [TestCase("2022-01-01T00:20:00Z", "2022-01-01T00:00:00Z", TestName = "startTime after endTime")]
+    public void TestGetCurrentForecastDataAsync_InvalidStartEndTimes_ThrowsException(string start, string end)
     {
         this.CarbonIntensityDataSource.Setup(x => x.GetCurrentCarbonIntensityForecastAsync(It.IsAny<Location>()))
             .ReturnsAsync(TestData.GetForecast("2022-01-01T00:00:00Z"));
@@ -220,6 +201,5 @@ public class CarbonAwareAggregatorTests
             { CarbonAwareConstants.End, end }
         };
         Assert.ThrowsAsync<ArgumentException>(async () => await Aggregator.GetCurrentForecastDataAsync(props));
-        return Task.CompletedTask;
     }
 }

--- a/src/CarbonAware.Aggregators/test/CarbonAwareAggregatorTests.cs
+++ b/src/CarbonAware.Aggregators/test/CarbonAwareAggregatorTests.cs
@@ -52,9 +52,9 @@ public class CarbonAwareAggregatorTests
         var props = new Dictionary<string, object>()
         {
             { CarbonAwareConstants.Locations, new List<Location>() { new Location() { RegionName = "westus" } } },
+            { CarbonAwareConstants.Start, start },
+            { CarbonAwareConstants.End, end },
         };
-        if (start != null) { props.Add(CarbonAwareConstants.Start, start); }
-        if (end != null) { props.Add(CarbonAwareConstants.End, end); }
 
         // Act
         var results = await this.Aggregator.GetCurrentForecastDataAsync(props);
@@ -79,8 +79,8 @@ public class CarbonAwareAggregatorTests
         Assert.IsEmpty(results);
     }
 
-    [TestCase("2022-01-01T00:00:00Z", "2022-01-01T00:20:00Z", ExpectedResult = 4)] // Start and end time match
-    [TestCase("2022-01-01T00:02:00Z", "2022-01-01T00:12:00Z", ExpectedResult = 3)] // Start time match and end midway through a datapoint
+    [TestCase("2022-01-01T00:00:00Z", "2022-01-01T00:20:00Z", ExpectedResult = 4, TestName = "Start and end time match")]
+    [TestCase("2022-01-01T00:02:00Z", "2022-01-01T00:12:00Z", ExpectedResult = 3, TestName = "Start and end match midway through a datapoint")]
     public async Task<int> TestGetCurrentForecastDataAsync_FiltersDate(string start, string end)
     {
         this.CarbonIntensityDataSource.Setup(x => x.GetCurrentCarbonIntensityForecastAsync(It.IsAny<Location>()))
@@ -98,8 +98,8 @@ public class CarbonAwareAggregatorTests
         return forecastData.Count();
     }
 
-    [TestCase("2022-01-01T00:00:00Z", "2022-01-01T00:20:00Z")] // full data set
-    [TestCase("2022-01-01T00:05:00Z", "2022-01-01T00:20:00Z")] // data set minus first lowest datapoint
+    [TestCase("2022-01-01T00:00:00Z", "2022-01-01T00:20:00Z", TestName = "Full data set")]
+    [TestCase("2022-01-01T00:05:00Z", "2022-01-01T00:20:00Z", TestName = "Data set minus first lowest datapoint")]
     public async Task TestGetCurrentForecastDataAsync_OptimalDataPoint(string start, string end)
     {
         this.CarbonIntensityDataSource.Setup(x => x.GetCurrentCarbonIntensityForecastAsync(It.IsAny<Location>()))

--- a/src/CarbonAware.Aggregators/test/CarbonAwareAggregatorTests.cs
+++ b/src/CarbonAware.Aggregators/test/CarbonAwareAggregatorTests.cs
@@ -49,7 +49,7 @@ public class CarbonAwareAggregatorTests
         this.CarbonIntensityDataSource.Setup(x => x.GetCurrentCarbonIntensityForecastAsync(It.IsAny<Location>()))
             .ReturnsAsync(forecast);
 
-        var props = new Dictionary<string, object>()
+        var props = new Dictionary<string, object?>()
         {
             { CarbonAwareConstants.Locations, new List<Location>() { new Location() { RegionName = "westus" } } },
             { CarbonAwareConstants.Start, start },
@@ -194,7 +194,7 @@ public class CarbonAwareAggregatorTests
     {
         this.CarbonIntensityDataSource.Setup(x => x.GetCurrentCarbonIntensityForecastAsync(It.IsAny<Location>()))
             .ReturnsAsync(TestData.GetForecast("2022-01-01T00:00:00Z"));
-        var props = new Dictionary<string, object>()
+        var props = new Dictionary<string, object?>()
         {
             { CarbonAwareConstants.Locations, new List<Location>() { new Location() { RegionName = "westus" } } },
             { CarbonAwareConstants.Start, start },

--- a/src/CarbonAware.Aggregators/test/TestData.cs
+++ b/src/CarbonAware.Aggregators/test/TestData.cs
@@ -51,9 +51,9 @@ public static class TestData
         };
     }
 
-    public static EmissionsForecast GetForecast(int durationMinutes = 5)
+    public static EmissionsForecast GetForecast(string start, int durationMinutes = 5)
     {
-        var startTime = DateTimeOffset.Parse("2022-01-01T00:00:00Z");
+        var startTime = DateTimeOffset.Parse(start);
         var duration = TimeSpan.FromMinutes(durationMinutes);
         var forecastData = new List<EmissionsData>()
         {

--- a/src/CarbonAware.WebApi/src/Controllers/CarbonAwareController.cs
+++ b/src/CarbonAware.WebApi/src/Controllers/CarbonAwareController.cs
@@ -115,13 +115,33 @@ public class CarbonAwareController : ControllerBase
     }
 
     /// <summary>
-    /// Maps user input query parameters to props dictionary for use with the data sources current forecast method.
+    ///   Retrieves the most recent forecasted data and calculates the optimal marginal carbon intensity window.
     /// </summary>
-    /// <param name="locations"> String array of named locations.</param>
-    /// <param name="startTime"> Start time of forecast period.</param>
-    /// <param name="endTime"> End time of forecast period.</param>
-    /// <param name="windowSize"> Size of rolling average window in minutes.</param>
-    /// <returns>HTTP response containing the results of the data source current forecast call</returns>
+    /// <param name="location"> String array of named locations.</param>
+    /// <param name="startTime">
+    ///   Start time boundary of forecasted data points. Ignores current forecast data points before this time.
+    ///   Defaults to the earliest time in the forecast data.
+    /// </param>
+    /// <param name="endTime">
+    ///   End time boundary of forecasted data points. Ignores current forecast data points after this time.
+    ///   Defaults to the latest time in the forecast data.
+    /// </param>
+    /// <param name="windowSize">The estimated duration (in minutes) of the workload.</param>
+    /// <remarks>
+    ///   This endpoint fetches the most recent forecast for all provided locations and calculates the optimal 
+    ///   marginal carbon intensity windows (per the specified windowSize) for each, within the start and end time boundaries.
+    ///   If no start or end time boundaries are provided, all forecasted data points are used. 
+    ///
+    ///   The forecast data represents what the data source predicts future marginal carbon intesity values to be, 
+    ///   not actual measured emissions data (as future values cannot be known).
+    ///
+    ///   This endpoint is useful for determining if there is a more carbon-optimal time to use electicity predicted in the future.
+    /// </remarks>
+    /// <returns>An array of forecasts (one per requested location) with their optimal marginal carbon intensity windows.</returns>
+    /// <response code="200">Returns the requested forecast objects</response>
+    /// <response code="400">Returned if any of the input parameters are invalid</response>
+    /// <response code="500">Internal server error</response>
+    /// <response code="501">Returned if the underlying data source does not support forecasting</response>
     [Produces("application/json")]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<EmissionsForecastDTO>))]
     [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(ValidationProblemDetails))]

--- a/src/CarbonAware.WebApi/src/Controllers/CarbonAwareController.cs
+++ b/src/CarbonAware.WebApi/src/Controllers/CarbonAwareController.cs
@@ -117,7 +117,7 @@ public class CarbonAwareController : ControllerBase
     /// <summary>
     ///   Retrieves the most recent forecasted data and calculates the optimal marginal carbon intensity window.
     /// </summary>
-    /// <param name="location"> String array of named locations.</param>
+    /// <param name="locations"> String array of named locations.</param>
     /// <param name="startTime">
     ///   Start time boundary of forecasted data points. Ignores current forecast data points before this time.
     ///   Defaults to the earliest time in the forecast data.
@@ -151,11 +151,11 @@ public class CarbonAwareController : ControllerBase
     [ProducesResponseType(StatusCodes.Status500InternalServerError, Type = typeof(ValidationProblemDetails))]
     [ProducesResponseType(StatusCodes.Status501NotImplemented, Type = typeof(ValidationProblemDetails))]
     [HttpGet("forecasts/current")]
-    public async Task<IActionResult> GetCurrentForecastData([FromQuery(Name = "location"), BindRequired] string[] location, DateTimeOffset? startTime = null, DateTimeOffset? endTime = null, int? windowSize = null)
+    public async Task<IActionResult> GetCurrentForecastData([FromQuery(Name = "location"), BindRequired] string[] locations, DateTimeOffset? startTime = null, DateTimeOffset? endTime = null, int? windowSize = null)
     {
         using (var activity = Activity.StartActivity())
         {
-            IEnumerable<Location> locationEnumerable = CreateLocationsFromQueryString(location);
+            IEnumerable<Location> locationEnumerable = CreateLocationsFromQueryString(locations);
             var props = new Dictionary<string, object?>() {
                 { CarbonAwareConstants.Locations, locationEnumerable },
                 { CarbonAwareConstants.Start, startTime },

--- a/src/CarbonAware.WebApi/src/Controllers/CarbonAwareController.cs
+++ b/src/CarbonAware.WebApi/src/Controllers/CarbonAwareController.cs
@@ -126,7 +126,10 @@ public class CarbonAwareController : ControllerBase
     ///   End time boundary of forecasted data points. Ignores current forecast data points after this time.
     ///   Defaults to the latest time in the forecast data.
     /// </param>
-    /// <param name="windowSize">The estimated duration (in minutes) of the workload.</param>
+    /// <param name="windowSize">
+    ///   The estimated duration (in minutes) of the workload.
+    ///   Defaults to the duration of a single forecast data point.
+    /// </param>
     /// <remarks>
     ///   This endpoint fetches the most recent forecast for all provided locations and calculates the optimal 
     ///   marginal carbon intensity windows (per the specified windowSize) for each, within the start and end time boundaries.
@@ -148,11 +151,11 @@ public class CarbonAwareController : ControllerBase
     [ProducesResponseType(StatusCodes.Status500InternalServerError, Type = typeof(ValidationProblemDetails))]
     [ProducesResponseType(StatusCodes.Status501NotImplemented, Type = typeof(ValidationProblemDetails))]
     [HttpGet("forecasts/current")]
-    public async Task<IActionResult> GetCurrentForecastData([FromQuery(Name = "location"), BindRequired] string[] locations, DateTimeOffset? startTime = null, DateTimeOffset? endTime = null, int? windowSize = null)
+    public async Task<IActionResult> GetCurrentForecastData([FromQuery(Name = "location"), BindRequired] string[] location, DateTimeOffset? startTime = null, DateTimeOffset? endTime = null, int? windowSize = null)
     {
         using (var activity = Activity.StartActivity())
         {
-            IEnumerable<Location> locationEnumerable = CreateLocationsFromQueryString(locations);
+            IEnumerable<Location> locationEnumerable = CreateLocationsFromQueryString(location);
             var props = new Dictionary<string, object?>() {
                 { CarbonAwareConstants.Locations, locationEnumerable },
                 { CarbonAwareConstants.Start, startTime },

--- a/src/CarbonAware.WebApi/src/Filters/HttpResponseExceptionFilter.cs
+++ b/src/CarbonAware.WebApi/src/Filters/HttpResponseExceptionFilter.cs
@@ -1,9 +1,11 @@
 using CarbonAware.Interfaces;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
-using System.Net;
-using System.Diagnostics;
 using Microsoft.Extensions.Options;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Net;
 
 namespace CarbonAware.WebApi.Filters;
 
@@ -70,6 +72,15 @@ public class HttpResponseExceptionFilter : IExceptionFilter
         if (traceId != null)
         {
             response.Extensions["traceId"] = traceId;
+        }
+
+        foreach (DictionaryEntry entry in context.Exception.Data)
+        {
+            var k = entry.Key.ToString();
+            var v = entry.Value?.ToString();
+            var errorList = response.Errors.ContainsKey(k) ? response.Errors[k].ToList() : new List<string>();
+            errorList.Add(v);
+            response.Errors[k] = errorList.ToArray();
         }
 
         context.Result = new ObjectResult(response)

--- a/src/CarbonAware.WebApi/src/Filters/HttpResponseExceptionFilter.cs
+++ b/src/CarbonAware.WebApi/src/Filters/HttpResponseExceptionFilter.cs
@@ -76,11 +76,9 @@ public class HttpResponseExceptionFilter : IExceptionFilter
 
         foreach (DictionaryEntry entry in context.Exception.Data)
         {
-            var k = entry.Key.ToString();
-            var v = entry.Value?.ToString();
-            var errorList = response.Errors.ContainsKey(k) ? response.Errors[k].ToList() : new List<string>();
-            errorList.Add(v);
-            response.Errors[k] = errorList.ToArray();
+            if (entry.Value is string[] messages && entry.Key.ToString() is string key){
+                response.Errors[key] = messages;
+            }
         }
 
         context.Result = new ObjectResult(response)

--- a/src/CarbonAware.WebApi/src/Filters/HttpResponseExceptionFilter.cs
+++ b/src/CarbonAware.WebApi/src/Filters/HttpResponseExceptionFilter.cs
@@ -76,7 +76,7 @@ public class HttpResponseExceptionFilter : IExceptionFilter
 
         foreach (DictionaryEntry entry in context.Exception.Data)
         {
-            if (entry.Value is string[] messages && entry.Key.ToString() is string key){
+            if (entry.Value is string[] messages && entry.Key is string key){
                 response.Errors[key] = messages;
             }
         }

--- a/src/CarbonAware.WebApi/test/integrationTests/CarbonAwareControllerTests.cs
+++ b/src/CarbonAware.WebApi/test/integrationTests/CarbonAwareControllerTests.cs
@@ -114,7 +114,7 @@ public class CarbonAwareControllerTests : IntegrationTestingBase
     }
 
     [Test]
-    public async Task EmissionsForecastsCurrent_StartAndEndOutsideWindow_ReturnsEmptyForecast()
+    public async Task EmissionsForecastsCurrent_StartAndEndOutsideWindow_ReturnsBadRequest()
     {
         IgnoreTestForDataSource("data source does not implement '/emissions/forecasts/current'", DataSourceType.JSON);
 
@@ -131,7 +131,7 @@ public class CarbonAwareControllerTests : IntegrationTestingBase
 
         var result = await _client.GetAsync(endpointURI);
         Assert.That(result, Is.Not.Null);
-        Assert.That(result.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+        Assert.That(result.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest));
     }
 
     [TestCase("location", "", TestName = "empty location query string")]

--- a/src/CarbonAware.WebApi/test/integrationTests/mocks/WattTimeDataSourceMocker.cs
+++ b/src/CarbonAware.WebApi/test/integrationTests/mocks/WattTimeDataSourceMocker.cs
@@ -62,7 +62,8 @@ public class WattTimeDataSourceMocker : IDataSourceMocker
     {
         var curr = DateTimeOffset.UtcNow;
         var d = TimeSpan.FromMinutes(5);
-        var start = new DateTimeOffset((curr.Ticks + d.Ticks - 1) / d.Ticks * d.Ticks, TimeSpan.Zero);
+        // Calculate nearest 5 minute increment from now to match expected WattTime data points.
+        var start = new DateTimeOffset(((curr.Ticks + d.Ticks - 1) / d.Ticks) * d.Ticks, TimeSpan.Zero);
         var end = start + TimeSpan.FromDays(1.0);
         var pointTime = start;
         var ForecastData = new List<GridEmissionDataPoint>();

--- a/src/CarbonAware.WebApi/test/integrationTests/mocks/WattTimeDataSourceMocker.cs
+++ b/src/CarbonAware.WebApi/test/integrationTests/mocks/WattTimeDataSourceMocker.cs
@@ -60,7 +60,9 @@ public class WattTimeDataSourceMocker : IDataSourceMocker
 
     public void SetupForecastMock()
     {
-        var start = DateTimeOffset.Now.ToUniversalTime();
+        var curr = DateTimeOffset.UtcNow;
+        var d = TimeSpan.FromMinutes(5);
+        var start = new DateTimeOffset((curr.Ticks + d.Ticks - 1) / d.Ticks * d.Ticks, TimeSpan.Zero);
         var end = start + TimeSpan.FromDays(1.0);
         var pointTime = start;
         var ForecastData = new List<GridEmissionDataPoint>();

--- a/src/CarbonAware.WebApi/test/unitTests/HttpResponseExceptionFilterTests.cs
+++ b/src/CarbonAware.WebApi/test/unitTests/HttpResponseExceptionFilterTests.cs
@@ -107,9 +107,12 @@ public class HttpResponseExceptionFilterTests
     {
         // Arrange
         var ex = new ArgumentException("My validation error");
-        ex.Data["objectValue"] = new Object();
-        ex.Data["stringValue"] = "myString";
-        ex.Data["listValue"] = new List<string>() { "myListString" };
+        ex.Data["objectValue"]      = new Object();
+        ex.Data["stringValue"]      = "myString";
+        ex.Data["listValue"]        = new List<string>() { "myListString" };
+        ex.Data[1]                  = new string[] { "validValue, invalidKey" };
+        ex.Data[new Object()]       = new string[] { "validValue, invalidKey" };
+        ex.Data[new List<string>()] = new string[] { "validValue, invalidKey" };
 
         var exceptionContext = new ExceptionContext(this._actionContext, new List<IFilterMetadata>())
         {

--- a/src/CarbonAware.WebApi/test/unitTests/HttpResponseExceptionFilterTests.cs
+++ b/src/CarbonAware.WebApi/test/unitTests/HttpResponseExceptionFilterTests.cs
@@ -17,11 +17,11 @@ namespace CarbonAware.WepApi.UnitTests;
 public class HttpResponseExceptionFilterTests
 {
     // Not relevant for tests which populate this field via the [SetUp] attribute.
-    #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
     private ActionContext _actionContext;
     private Mock<ILogger<HttpResponseExceptionFilter>> _logger;
 
-    #pragma warning restore CS8618
+#pragma warning restore CS8618
 
     [SetUp]
     public void Setup()
@@ -60,11 +60,21 @@ public class HttpResponseExceptionFilterTests
         Assert.AreEqual(ex.Detail, content.Detail);
     }
 
-    [Test]
-    public void TestOnException_ArgumentException()
+    [TestCase("key1", null, new string[] { "message one" }, TestName = "single key, single message")]
+    [TestCase("key1", null, new string[] { "message one", "message two" }, TestName = "single key, multiple messages")]
+    [TestCase("key1", "key2", new string[] { "message one" }, TestName = "multiple keys, single message")]
+    [TestCase("key1", "key2", new string[] { "message one", "message two" }, TestName = "multiple keys, multiple messages")]
+    public void TestOnException_ArgumentException_ValidErrorDataInResponse(string firstKey, string secondKey, params string[] values)
     {
         // Arrange
         var ex = new ArgumentException("My validation error");
+        ex.Data[firstKey] = values;
+        if (secondKey != null) { ex.Data[secondKey] = values; }
+
+        var expectedErrorMessage = new Dictionary<string, string[]>();
+        expectedErrorMessage.Add(firstKey, values);
+        if (secondKey != null) { expectedErrorMessage.Add(secondKey, values); }
+
         var exceptionContext = new ExceptionContext(this._actionContext, new List<IFilterMetadata>())
         {
             Exception = ex
@@ -89,6 +99,43 @@ public class HttpResponseExceptionFilterTests
         Assert.AreEqual((int)HttpStatusCode.BadRequest, content!.Status);
         Assert.AreEqual("ArgumentException", content.Title);
         Assert.AreEqual("My validation error", content.Detail);
+        Assert.AreEqual(expectedErrorMessage, content.Errors);
+    }
+
+    [Test]
+    public void TestOnException_ArgumentException_InvalidErrorDataOmittedInResponse()
+    {
+        // Arrange
+        var ex = new ArgumentException("My validation error");
+        ex.Data["objectValue"] = new Object();
+        ex.Data["stringValue"] = "myString";
+        ex.Data["listValue"] = new List<string>() { "myListString" };
+
+        var exceptionContext = new ExceptionContext(this._actionContext, new List<IFilterMetadata>())
+        {
+            Exception = ex
+        };
+        CarbonAwareVariablesConfiguration config = new CarbonAwareVariablesConfiguration()
+        {
+            VerboseApi = false
+        };
+        var mockIOption = new Mock<IOptionsMonitor<CarbonAwareVariablesConfiguration>>();
+        mockIOption.Setup(ap => ap.CurrentValue).Returns(config);
+
+        var filter = new HttpResponseExceptionFilter(this._logger.Object, mockIOption.Object);
+
+        // Act
+        filter.OnException(exceptionContext);
+
+        // Assert
+        (var result, var content) = GetExceptionContextDetails(exceptionContext);
+
+        Assert.IsTrue(exceptionContext.ExceptionHandled);
+        Assert.AreEqual((int)HttpStatusCode.BadRequest, result!.StatusCode);
+        Assert.AreEqual((int)HttpStatusCode.BadRequest, content!.Status);
+        Assert.AreEqual("ArgumentException", content.Title);
+        Assert.AreEqual("My validation error", content.Detail);
+        Assert.AreEqual(0, content.Errors.Keys.Count);
     }
 
     [Test]

--- a/src/CarbonAware/src/Model/EmissionsForecast.cs
+++ b/src/CarbonAware/src/Model/EmissionsForecast.cs
@@ -68,7 +68,6 @@ public record EmissionsForecast
             ArgumentException error = new ArgumentException("Invalid EmissionsForecast");
             foreach (KeyValuePair<string, List<string>> message in errors)
             {
-                Console.WriteLine($"Pair here: {message.Key}, {message.Value}");
                 error.Data[message.Key] = message.Value.ToArray();
             }
             throw error;

--- a/src/CarbonAware/src/Model/EmissionsForecast.cs
+++ b/src/CarbonAware/src/Model/EmissionsForecast.cs
@@ -66,6 +66,11 @@ public record EmissionsForecast
         if (errors.Keys.Count > 0)
         {
             ArgumentException error = new ArgumentException("Invalid EmissionsForecast");
+            foreach (KeyValuePair<string, List<string>> message in errors)
+            {
+                Console.WriteLine($"Pair here: {message.Key}, {message.Value}");
+                error.Data[message.Key] = message.Value.ToArray();
+            }
             throw error;
         }
     }

--- a/src/CarbonAware/src/Model/EmissionsForecast.cs
+++ b/src/CarbonAware/src/Model/EmissionsForecast.cs
@@ -1,5 +1,7 @@
 namespace CarbonAware.Model;
 
+using System.ComponentModel.DataAnnotations;
+
 public record EmissionsForecast
 {
     /// <summary>
@@ -36,4 +38,44 @@ public record EmissionsForecast
     /// Gets or sets the optimal data point within the ForecastData set.
     /// </summary>
     public EmissionsData OptimalDataPoint { get; set; }
+
+
+    public void Validate()
+    {
+        var errors = new Dictionary<string, List<string>>();
+        var firstDataPoint = ForecastData.First();
+        var lastDataPoint = ForecastData.Last();
+        var minTime = firstDataPoint.Time;
+        var maxTime = lastDataPoint.Time + lastDataPoint.Duration;
+
+        if (StartTime >= EndTime)
+        {
+            AddErrorMessage(errors, "startTime", "startTime must be earlier than endTime");
+        }
+
+        if (StartTime < minTime || StartTime > maxTime)
+        {
+            AddErrorMessage(errors, "startTime", $"startTime must be within time range of the forecasted data, '{minTime}' through '{maxTime}'");
+        }
+
+        if (EndTime < minTime || EndTime > maxTime)
+        {
+            AddErrorMessage(errors, "endTime", $"endTime must be within time range of the forecasted data, '{minTime}' through '{maxTime}'");
+        }
+
+        if (errors.Keys.Count > 0)
+        {
+            ArgumentException error = new ArgumentException("Invalid EmissionsForecast");
+            throw error;
+        }
+    }
+
+    private void AddErrorMessage(Dictionary<string, List<string>> errors, string key, string message)
+    {
+        if (!errors.ContainsKey(key))
+        {
+            errors[key] = new List<string>();
+        }
+        errors[key].Add(message);
+    }
 }


### PR DESCRIPTION
Issue Number: 442
## Summary
Adds input validation for current forecast dates and improves default values.

## Changes

- Improved documentation
- startTime and endTime validation
- improved startTime and endTime defaults when not specified
- Exception filter surfaces all validation error details to the user.
- Update unit/integration tests to reflect new expectations

## Checklist

- [x] Local Tests Passing?
- [x] CICD and Pipeline Tests Passing?
- [x] Added any new Tests?
- [x] Documentation Updates Made?
- [x] Are there any API Changes? No
- [x] This is not a breaking change.

## Are there API Changes? No

## Is this a breaking change? No

## Anything else?

