### PR TITLE
448/env variables doc update

### DIFF
--- a/GettingStarted.md
+++ b/GettingStarted.md
@@ -151,7 +151,7 @@ CarbonAwareVars__WebApiRoutePrefix="/microsoft/cse/fsi"
 CarbonAwareVars__Proxy__UseProxy=true
 CarbonAwareVars__Proxy__Url="http://10.10.10.1"
 CarbonAwareVars__Proxy__Username="proxyUsername"
-CarbonAwareVars__Proxy__Uassword="proxyPassword"
+CarbonAwareVars__Proxy__Password="proxyPassword"
 WattTimeClient__Username="wattTimeUsername"
 WattTimeClient__Password="wattTimePassword"
 ```

--- a/GettingStarted.md
+++ b/GettingStarted.md
@@ -129,31 +129,31 @@ This project is using standard [Microsoft.Extensions.Logging](https://docs.micro
 Application monitoring and tracing can be configured using the `TelemetryProvider` variable in the application configuration.  
 
 ```bash
-carbonAwareVars__TelemetryProvider= "ApplicationInsights"
+CarbonAwareVars__TelemetryProvider="ApplicationInsights"
 ```
 This application is integrated with Application Insights for monitoring purposes. The telemetry collected in the app is pushed to AppInsights and can be tracked for logs, exceptions, traces and more. To connect to your Application Insights instance, configure the `APPLICATIONINSIGHTS_CONNECTION_STRING` variable
 
 ```bash
-APPLICATIONINSIGHTS_CONNECTION_STRING= "AppInsightsConnectionString"
+APPLICATIONINSIGHTS_CONNECTION_STRING="AppInsightsConnectionString"
 ```
 
 ### Verbosity 
 You can configure the verbosity of the application error messages by setting the 'VerboseApi' enviroment variable. Typically, you would set this value to 'true' in the development or staging regions. When set to 'true', a detailed stack trace would be presented for any errors in the request. 
 ```bash
-carbonAwareVars__VerboseApi= "true"
+CarbonAwareVars__VerboseApi="true"
 ```
 
 ### Sample Environment Variable Configuration Using WattTime
 
 ```bash
-carbonAwareVars__carbonIntensityDataSource="WattTime"
-carbonAwareVars__webApiRoutePrefix="/microsoft/cse/fsi"
-carbonAwareVars__proxy__useProxy=true
-carbonAwareVars__proxy__url="http://10.10.10.1"
-carbonAwareVars__proxy__username="proxyUsername"
-carbonAwareVars__proxy__password="proxyPassword"
-wattTimeClient__username="wattTimeUsername"
-wattTimeClient__password="wattTimePassword"
+CarbonAwareVars__CarbonIntensityDataSource="WattTime"
+CarbonAwareVars__WebApiRoutePrefix="/microsoft/cse/fsi"
+CarbonAwareVars__Proxy__UseProxy=true
+CarbonAwareVars__Proxy__Url="http://10.10.10.1"
+CarbonAwareVars__Proxy__Username="proxyUsername"
+CarbonAwareVars__Proxy__Uassword="proxyPassword"
+wattTimeClient__Username="wattTimeUsername"
+wattTimeClient__Password="wattTimePassword"
 ```
 
 ### Sample Json Configuration Using WattTime

--- a/GettingStarted.md
+++ b/GettingStarted.md
@@ -152,8 +152,8 @@ CarbonAwareVars__Proxy__UseProxy=true
 CarbonAwareVars__Proxy__Url="http://10.10.10.1"
 CarbonAwareVars__Proxy__Username="proxyUsername"
 CarbonAwareVars__Proxy__Uassword="proxyPassword"
-wattTimeClient__Username="wattTimeUsername"
-wattTimeClient__Password="wattTimePassword"
+WattTimeClient__Username="wattTimeUsername"
+WattTimeClient__Password="wattTimePassword"
 ```
 
 ### Sample Json Configuration Using WattTime

--- a/GettingStarted.md
+++ b/GettingStarted.md
@@ -22,7 +22,7 @@ The WebAPI project uses standard configuration sources provided by [ASPNetCore](
 
 Please note that configuration is heirarchical.  The last configuration source loaded that contains a configuration value will be the value that's used.  This means that if the same configuration value is found in both appsettings.json and as an environment variable, the value from the environment variable will be the value that's applied.
 
-When adding values via environment variables, we recommend that you use the double underscore form, rather than the colon form.  Colons won't work in non-windows environment.  For example:
+When adding values via environment variables, we recommend that you use the double underscore form, rather than the colon form.  Colons won't work in non-windows environment.   For example:
 
 ```bash
   CarbonAwareVars__CarbonIntensityDataSource="WattTime"
@@ -126,10 +126,10 @@ In normal use, you shouldn't need to set this value, but this value can be used 
 This project is using standard [Microsoft.Extensions.Logging](https://docs.microsoft.com/en-us/dotnet/core/extensions/logging?tabs=command-line).  To configure different log levels, please see the documentation at this link.
 
 ### Tracing and Monitoring Configuration
-Application monitoring and tracing can be configured using the `TELEMETRY_PROVIDER` variable in the application configuration
+Application monitoring and tracing can be configured using the `TelemetryProvider` environment variable.  
 
 ```bash
-TELEMETRY_PROVIDER= "ApplicationInsights"
+carbonAwareVars__TelemetryProvider= "ApplicationInsights"
 ```
 This application is integrated with Application Insights for monitoring purposes. The telemetry collected in the app is pushed to AppInsights and can be tracked for logs, exceptions, traces and more. To connect to your Application Insights instance, configure the `APPLICATIONINSIGHTS_CONNECTION_STRING` variable
 
@@ -137,6 +137,11 @@ This application is integrated with Application Insights for monitoring purposes
 APPLICATIONINSIGHTS_CONNECTION_STRING= "AppInsightsConnectionString"
 ```
 
+### Verbosity 
+You can configure the verbosity of the application error messages by setting the 'VerboseApi' enviroment variable. Typically, you would set this value to 'true' in the development or staging regions. When set to 'true', a detailed stack trace would be presented for any errors in the request. 
+```bash
+carbonAwareVars__VerboseApi= "true"
+```
 
 ### Sample Environment Variable Configuration Using WattTime
 

--- a/GettingStarted.md
+++ b/GettingStarted.md
@@ -22,7 +22,7 @@ The WebAPI project uses standard configuration sources provided by [ASPNetCore](
 
 Please note that configuration is heirarchical.  The last configuration source loaded that contains a configuration value will be the value that's used.  This means that if the same configuration value is found in both appsettings.json and as an environment variable, the value from the environment variable will be the value that's applied.
 
-When adding values via environment variables, we recommend that you use the double underscore form, rather than the colon form.  Colons won't work in non-windows environment.   For example:
+When adding values via environment variables, we recommend that you use the double underscore form, rather than the colon form.  Colons won't work in non-windows environment.  For example:
 
 ```bash
   CarbonAwareVars__CarbonIntensityDataSource="WattTime"
@@ -126,7 +126,7 @@ In normal use, you shouldn't need to set this value, but this value can be used 
 This project is using standard [Microsoft.Extensions.Logging](https://docs.microsoft.com/en-us/dotnet/core/extensions/logging?tabs=command-line).  To configure different log levels, please see the documentation at this link.
 
 ### Tracing and Monitoring Configuration
-Application monitoring and tracing can be configured using the `TelemetryProvider` environment variable.  
+Application monitoring and tracing can be configured using the `TelemetryProvider` variable in the application configuration.  
 
 ```bash
 carbonAwareVars__TelemetryProvider= "ApplicationInsights"


### PR DESCRIPTION
Issue Number: https://dev.azure.com/ZakimCSE/UBS%20Carbon-Aware/_workitems/edit/448

## Summary
Updated documentation to correctly represent how to set the Telemetry provider and configure Verbosity of error messages

## Changes

Updated GettingStarted.md

## Checklist

- [x ] Local Tests Passing?
- [x ] CICD and Pipeline Tests Passing?
- [ ] Added any new Tests?
- [x ] Documentation Updates Made?
- [ ] Are there any API Changes? If yes, please describe below.
- [x ] This is not a breaking change. If it is, please describe it below.

