### PR TITLE
Update readme with new start/end params

### DIFF
--- a/src/CarbonAware.Aggregators/src/CarbonAware/CarbonAwareAggregator.cs
+++ b/src/CarbonAware.Aggregators/src/CarbonAware/CarbonAwareAggregator.cs
@@ -57,10 +57,10 @@ public class CarbonAwareAggregator : ICarbonAwareAggregator
                 var forecast = await this._dataSource.GetCurrentCarbonIntensityForecastAsync(location);
                 var firstDataPoint = forecast.ForecastData.First();
                 var lastDataPoint = forecast.ForecastData.Last();
-                forecast.StartTime = GetOffsetOrDefault(props, CarbonAwareConstants.Start, firstDataPoint.Time);
-                forecast.EndTime = GetOffsetOrDefault(props, CarbonAwareConstants.End, lastDataPoint.Time + lastDataPoint.Duration);
+                forecast.DataStartAt = GetOffsetOrDefault(props, CarbonAwareConstants.Start, firstDataPoint.Time);
+                forecast.DataEndAt = GetOffsetOrDefault(props, CarbonAwareConstants.End, lastDataPoint.Time + lastDataPoint.Duration);
                 forecast.Validate();
-                forecast.ForecastData = IntervalHelper.FilterByDuration(forecast.ForecastData, forecast.StartTime, forecast.EndTime);
+                forecast.ForecastData = IntervalHelper.FilterByDuration(forecast.ForecastData, forecast.DataStartAt, forecast.DataEndAt);
                 forecast.ForecastData = forecast.ForecastData.RollingAverage(windowSize);
                 forecast.OptimalDataPoint = GetOptimalEmissions(forecast.ForecastData);
                 if (forecast.ForecastData.Any())

--- a/src/CarbonAware.Aggregators/test/CarbonAwareAggregatorTests.cs
+++ b/src/CarbonAware.Aggregators/test/CarbonAwareAggregatorTests.cs
@@ -61,8 +61,8 @@ public class CarbonAwareAggregatorTests
 
         // Assert
         var forecastResult = results.First();
-        Assert.AreEqual(expectedStart, forecastResult.StartTime);
-        Assert.AreEqual(expectedEnd, forecastResult.EndTime);
+        Assert.AreEqual(expectedStart, forecastResult.DataStartAt);
+        Assert.AreEqual(expectedEnd, forecastResult.DataEndAt);
     }
 
     [Test]

--- a/src/CarbonAware.Aggregators/test/CarbonAwareAggregatorTests.cs
+++ b/src/CarbonAware.Aggregators/test/CarbonAwareAggregatorTests.cs
@@ -33,18 +33,18 @@ public class CarbonAwareAggregatorTests
         this.Aggregator = new CarbonAwareAggregator(this.Logger.Object, this.CarbonIntensityDataSource.Object);
     }
 
-    [TestCase(null, null, TestName = "no start param, no end param")]
-    [TestCase("2022-01-01T00:05:00Z", null, TestName = "start param, no end param")]
-    [TestCase(null, "2022-01-01T00:15:00Z", TestName = "no start param, end param")]
-    [TestCase("2022-01-01T00:05:00Z", "2022-01-01T00:15:00Z", TestName = "start param, end param")]
-    public async Task TestGetCurrentForecastDataAsync_StartAndEndUsePropsOrDefault(string start, string end)
+    [TestCase(null, null, TestName = "no dataStartAt param, no dataEndAt param")]
+    [TestCase("2022-01-01T00:05:00Z", null, TestName = "dataStartAt param, no dataEndAt param")]
+    [TestCase(null, "2022-01-01T00:15:00Z", TestName = "no dataStartAt param, dataEndAt param")]
+    [TestCase("2022-01-01T00:05:00Z", "2022-01-01T00:15:00Z", TestName = "dataStartAt param, dataEndAt param")]
+    public async Task TestGetCurrentForecastDataAsync_StartAndEndUsePropsOrDefault(string dataStartAt, string dataEndAt)
     {
         // Arrange
         var forecast = TestData.GetForecast("2022-01-01T00:00:00Z");
         var firstDataPoint = forecast.ForecastData.First();
         var lastDataPoint = forecast.ForecastData.Last();
-        var expectedStart = start != null ? DateTimeOffset.Parse(start) : firstDataPoint.Time;
-        var expectedEnd = end != null ? DateTimeOffset.Parse(end) : lastDataPoint.Time + lastDataPoint.Duration;
+        var expectedStart = dataStartAt != null ? DateTimeOffset.Parse(dataStartAt) : firstDataPoint.Time;
+        var expectedEnd = dataEndAt != null ? DateTimeOffset.Parse(dataEndAt) : lastDataPoint.Time + lastDataPoint.Duration;
 
         this.CarbonIntensityDataSource.Setup(x => x.GetCurrentCarbonIntensityForecastAsync(It.IsAny<Location>()))
             .ReturnsAsync(forecast);
@@ -52,8 +52,8 @@ public class CarbonAwareAggregatorTests
         var props = new Dictionary<string, object?>()
         {
             { CarbonAwareConstants.Locations, new List<Location>() { new Location() { RegionName = "westus" } } },
-            { CarbonAwareConstants.Start, start },
-            { CarbonAwareConstants.End, end },
+            { CarbonAwareConstants.Start, dataStartAt },
+            { CarbonAwareConstants.End, dataEndAt },
         };
 
         // Act
@@ -79,17 +79,17 @@ public class CarbonAwareAggregatorTests
         Assert.IsEmpty(results);
     }
 
-    [TestCase("2022-01-01T00:00:00Z", "2022-01-01T00:20:00Z", ExpectedResult = 4, TestName = "Start and end time match")]
-    [TestCase("2022-01-01T00:02:00Z", "2022-01-01T00:12:00Z", ExpectedResult = 3, TestName = "Start and end match midway through a datapoint")]
-    public async Task<int> TestGetCurrentForecastDataAsync_FiltersDate(string start, string end)
+    [TestCase("2022-01-01T00:00:00Z", "2022-01-01T00:20:00Z", ExpectedResult = 4, TestName = "dataStartAt and dataEndAt match datapoint boundaries")]
+    [TestCase("2022-01-01T00:02:00Z", "2022-01-01T00:12:00Z", ExpectedResult = 3, TestName = "dataStartAt and dataEndAt match midway through datapoints")]
+    public async Task<int> TestGetCurrentForecastDataAsync_FiltersDate(string dataStartAt, string dataEndAt)
     {
         this.CarbonIntensityDataSource.Setup(x => x.GetCurrentCarbonIntensityForecastAsync(It.IsAny<Location>()))
             .ReturnsAsync(TestData.GetForecast("2022-01-01T00:00:00Z"));
         var props = new Dictionary<string, object>()
         {
             { CarbonAwareConstants.Locations, new List<Location>() { new Location() { RegionName = "westus" } } },
-            { CarbonAwareConstants.Start, start },
-            { CarbonAwareConstants.End, end }
+            { CarbonAwareConstants.Start, dataStartAt },
+            { CarbonAwareConstants.End, dataEndAt }
         };
 
         var results = await this.Aggregator.GetCurrentForecastDataAsync(props);
@@ -100,15 +100,15 @@ public class CarbonAwareAggregatorTests
 
     [TestCase("2022-01-01T00:00:00Z", "2022-01-01T00:20:00Z", TestName = "Full data set")]
     [TestCase("2022-01-01T00:05:00Z", "2022-01-01T00:20:00Z", TestName = "Data set minus first lowest datapoint")]
-    public async Task TestGetCurrentForecastDataAsync_OptimalDataPoint(string start, string end)
+    public async Task TestGetCurrentForecastDataAsync_OptimalDataPoint(string dataStartAt, string dataEndAt)
     {
         this.CarbonIntensityDataSource.Setup(x => x.GetCurrentCarbonIntensityForecastAsync(It.IsAny<Location>()))
             .ReturnsAsync(TestData.GetForecast("2022-01-01T00:00:00Z"));
         var props = new Dictionary<string, object>()
         {
             { CarbonAwareConstants.Locations, new List<Location>() { new Location() { RegionName = "westus" } } },
-            { CarbonAwareConstants.Start, start },
-            { CarbonAwareConstants.End, end }
+            { CarbonAwareConstants.Start, dataStartAt },
+            { CarbonAwareConstants.End, dataEndAt }
         };
 
         var results = await this.Aggregator.GetCurrentForecastDataAsync(props);
@@ -185,20 +185,20 @@ public class CarbonAwareAggregatorTests
         Assert.AreEqual(expectedData, forecast.ForecastData);
     }
 
-    [TestCase("2021-12-31T00:00:00Z", "2022-01-01T00:20:00Z", TestName = "early startTime, valid endTime")]
-    [TestCase("2022-01-01T00:00:00Z", "2022-01-01T00:30:00Z", TestName = "valid startTime, late endTime")]
-    [TestCase("2021-12-31T00:00:00Z", null, TestName = "early startTime, default endTime")]
-    [TestCase(null, "2022-01-01T00:30:00Z", TestName = "default startTime, late endTime")]
-    [TestCase("2022-01-01T00:20:00Z", "2022-01-01T00:00:00Z", TestName = "startTime after endTime")]
-    public void TestGetCurrentForecastDataAsync_InvalidStartEndTimes_ThrowsException(string start, string end)
+    [TestCase("2021-12-31T00:00:00Z", "2022-01-01T00:20:00Z", TestName = "early dataStartAt, valid dataEndAt")]
+    [TestCase("2022-01-01T00:00:00Z", "2022-01-01T00:30:00Z", TestName = "valid dataStartAt, late dataEndAt")]
+    [TestCase("2021-12-31T00:00:00Z", null, TestName = "early dataStartAt, default dataEndAt")]
+    [TestCase(null, "2022-01-01T00:30:00Z", TestName = "default dataStartAt, late dataEndAt")]
+    [TestCase("2022-01-01T00:20:00Z", "2022-01-01T00:00:00Z", TestName = "dataStartAt after dataEndAt")]
+    public void TestGetCurrentForecastDataAsync_InvalidDataStartAndEndAtTimes_ThrowsException(string dataStartAt, string dataEndAt)
     {
         this.CarbonIntensityDataSource.Setup(x => x.GetCurrentCarbonIntensityForecastAsync(It.IsAny<Location>()))
             .ReturnsAsync(TestData.GetForecast("2022-01-01T00:00:00Z"));
         var props = new Dictionary<string, object?>()
         {
             { CarbonAwareConstants.Locations, new List<Location>() { new Location() { RegionName = "westus" } } },
-            { CarbonAwareConstants.Start, start },
-            { CarbonAwareConstants.End, end }
+            { CarbonAwareConstants.Start, dataStartAt },
+            { CarbonAwareConstants.End, dataEndAt }
         };
         Assert.ThrowsAsync<ArgumentException>(async () => await Aggregator.GetCurrentForecastDataAsync(props));
     }

--- a/src/CarbonAware.WebApi/src/Controllers/CarbonAwareController.cs
+++ b/src/CarbonAware.WebApi/src/Controllers/CarbonAwareController.cs
@@ -131,10 +131,10 @@ public class CarbonAwareController : ControllerBase
     ///   Defaults to the duration of a single forecast data point.
     /// </param>
     /// <remarks>
-    ///   This endpoint fetches only the most recently generated forecast for all provided locations.  It filters down the full set  
-    ///   of forecasted data points using the "dataStartAt" and "dataEndAt" parameters. If no start or end time boundaries are 
-    ///   provided, all forecasted data points are used.  The data points are then used to calculate average marginal carbon 
-    ///   intensities of the specified "windowSize" and the optimal marginal carbon intensity window is identified.  
+    ///   This endpoint fetches only the most recently generated forecast for all provided locations.  It uses the "dataStartAt" and 
+    ///   "dataEndAt" parameters to scope the forecasted data points (if available for those times). If no start or end time 
+    ///   boundaries are provided, the entire forecast dataset is used. The scoped data points are used to calculate average marginal 
+    ///   carbon intensities of the specified "windowSize" and the optimal marginal carbon intensity window is identified.
     ///
     ///   The forecast data represents what the data source predicts future marginal carbon intesity values to be, 
     ///   not actual measured emissions data (as future values cannot be known).

--- a/src/CarbonAware.WebApi/src/Controllers/CarbonAwareController.cs
+++ b/src/CarbonAware.WebApi/src/Controllers/CarbonAwareController.cs
@@ -118,11 +118,11 @@ public class CarbonAwareController : ControllerBase
     ///   Retrieves the most recent forecasted data and calculates the optimal marginal carbon intensity window.
     /// </summary>
     /// <param name="locations"> String array of named locations.</param>
-    /// <param name="startTime">
+    /// <param name="dataStartAt">
     ///   Start time boundary of forecasted data points. Ignores current forecast data points before this time.
     ///   Defaults to the earliest time in the forecast data.
     /// </param>
-    /// <param name="endTime">
+    /// <param name="dataEndAt">
     ///   End time boundary of forecasted data points. Ignores current forecast data points after this time.
     ///   Defaults to the latest time in the forecast data.
     /// </param>
@@ -131,9 +131,10 @@ public class CarbonAwareController : ControllerBase
     ///   Defaults to the duration of a single forecast data point.
     /// </param>
     /// <remarks>
-    ///   This endpoint fetches the most recent forecast for all provided locations and calculates the optimal 
-    ///   marginal carbon intensity windows (per the specified windowSize) for each, within the start and end time boundaries.
-    ///   If no start or end time boundaries are provided, all forecasted data points are used. 
+    ///   This endpoint fetches only the most recently generated forecast for all provided locations.  It filters down the full set  
+    ///   of forecasted data points using the "dataStartAt" and "dataEndAt" parameters. If no start or end time boundaries are 
+    ///   provided, all forecasted data points are used.  The data points are then used to calculate average marginal carbon 
+    ///   intensities of the specified "windowSize" and the optimal marginal carbon intensity window is identified.  
     ///
     ///   The forecast data represents what the data source predicts future marginal carbon intesity values to be, 
     ///   not actual measured emissions data (as future values cannot be known).
@@ -151,15 +152,15 @@ public class CarbonAwareController : ControllerBase
     [ProducesResponseType(StatusCodes.Status500InternalServerError, Type = typeof(ValidationProblemDetails))]
     [ProducesResponseType(StatusCodes.Status501NotImplemented, Type = typeof(ValidationProblemDetails))]
     [HttpGet("forecasts/current")]
-    public async Task<IActionResult> GetCurrentForecastData([FromQuery(Name = "location"), BindRequired] string[] locations, DateTimeOffset? startTime = null, DateTimeOffset? endTime = null, int? windowSize = null)
+    public async Task<IActionResult> GetCurrentForecastData([FromQuery(Name = "location"), BindRequired] string[] locations, DateTimeOffset? dataStartAt = null, DateTimeOffset? dataEndAt = null, int? windowSize = null)
     {
         using (var activity = Activity.StartActivity())
         {
             IEnumerable<Location> locationEnumerable = CreateLocationsFromQueryString(locations);
             var props = new Dictionary<string, object?>() {
                 { CarbonAwareConstants.Locations, locationEnumerable },
-                { CarbonAwareConstants.Start, startTime },
-                { CarbonAwareConstants.End, endTime },
+                { CarbonAwareConstants.Start, dataStartAt },
+                { CarbonAwareConstants.End, dataEndAt },
                 { CarbonAwareConstants.Duration, windowSize },
             };
 

--- a/src/CarbonAware.WebApi/src/Models/EmissionsForecastBaseDTO.cs
+++ b/src/CarbonAware.WebApi/src/Models/EmissionsForecastBaseDTO.cs
@@ -6,6 +6,16 @@ using System.Text.Json.Serialization;
 [Serializable]
 public record EmissionsForecastBaseDTO
 {
+    /// <summary>
+    /// For current requests, this value is the timestamp the request for forecast data was made.
+    /// For historical forecast requests, this value is the timestamp used to access the most 
+    /// recently generated forecast as of that time. 
+    /// </summary>
+    /// <example>2022-06-01T00:03:30Z</example>
+    [JsonPropertyName("requestedAt")]
+    [Required()]
+    public DateTimeOffset RequestedAt { get; set; } = DateTimeOffset.UtcNow;
+
     /// <summary>The location of the forecast</summary>
     /// <example>eastus</example>
     [JsonPropertyName("location")]

--- a/src/CarbonAware.WebApi/src/Models/EmissionsForecastBaseDTO.cs
+++ b/src/CarbonAware.WebApi/src/Models/EmissionsForecastBaseDTO.cs
@@ -17,16 +17,16 @@ public record EmissionsForecastBaseDTO
     /// Defaults to the earliest time in the forecast data.
     /// </summary>
     /// <example>2022-06-01T12:00:00Z</example>
-    [JsonPropertyName("startTime")]
-    public DateTimeOffset StartTime { get; set; }
+    [JsonPropertyName("dataStartAt")]
+    public DateTimeOffset DataStartAt { get; set; }
 
     /// <summary>
     /// End time boundary of forecasted data points. Ignores forecast data points after this time.
     /// Defaults to the latest time in the forecast data.
     /// </summary>
     /// <example>2022-06-01T18:00:00Z</example>
-    [JsonPropertyName("endTime")]
-    public DateTimeOffset EndTime { get; set; }
+    [JsonPropertyName("dataEndAt")]
+    public DateTimeOffset DataEndAt { get; set; }
 
     /// <summary>
     /// The estimated duration (in minutes) of the workload.

--- a/src/CarbonAware.WebApi/src/Models/EmissionsForecastBatchDTO.cs
+++ b/src/CarbonAware.WebApi/src/Models/EmissionsForecastBatchDTO.cs
@@ -1,14 +1,6 @@
 namespace CarbonAware.WebApi.Models;
 
-using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
 
 [Serializable]
-public record EmissionsForecastBatchDTO : EmissionsForecastBaseDTO
-{
-  /// <summary>The historical time used to fetch the most recent forecast as of that time.</summary>
-  /// <example>2022-06-01T00:03:30Z</example>
-  [JsonPropertyName("requestedAt")]
-  [Required()]
-  public DateTimeOffset RequestedAt { get; set; }
-}
+public record EmissionsForecastBatchDTO : EmissionsForecastBaseDTO { }

--- a/src/CarbonAware.WebApi/src/Models/EmissionsForecastDTO.cs
+++ b/src/CarbonAware.WebApi/src/Models/EmissionsForecastDTO.cs
@@ -31,7 +31,7 @@ public record EmissionsForecastDTO : EmissionsForecastBaseDTO
     /// <summary>
     /// The forecasted data points transformed and filtered to reflect the specified time and window parameters.
     /// Points are ordered chronologically; Empty array if all data points were filtered out.
-    /// E.G. startTime and endTime outside the forecast period; windowSize greater than total duration of forecast data;
+    /// E.G. dataStartAt and dataEndAt times outside the forecast period; windowSize greater than total duration of forecast data;
     /// </summary>
     /// <example>
     /// [
@@ -64,8 +64,8 @@ public record EmissionsForecastDTO : EmissionsForecastBaseDTO
         {
             GeneratedAt = emissionsForecast.GeneratedAt,
             Location = emissionsForecast.Location.DisplayName,
-            StartTime = emissionsForecast.StartTime,
-            EndTime = emissionsForecast.EndTime,
+            DataStartAt = emissionsForecast.DataStartAt,
+            DataEndAt = emissionsForecast.DataEndAt,
             WindowSize = (int)emissionsForecast.WindowSize.TotalMinutes,
             OptimalDataPoint = EmissionsDataDTO.FromEmissionsData(emissionsForecast.OptimalDataPoint),
             ForecastData = emissionsForecast.ForecastData.Select(d => EmissionsDataDTO.FromEmissionsData(d))!

--- a/src/CarbonAware.WebApi/src/README.md
+++ b/src/CarbonAware.WebApi/src/README.md
@@ -169,8 +169,8 @@ This endpoint is useful for determining if there is a more carbon-optimal time t
 
 Parameters:
 1. `location`: This is a required parameter and is an array of the names of the data region for the configured Cloud provider.
-2. `dataStartAt`: Start time boundary of the current forecast data points. Ignores current forecast data points before this time. It defaults to the earliest time in the forecast data.
-3. `dataEndAt`: End time boundary of the current forecast data points. Ignores current forecast data points after this time. Defaults to the latest time in the forecast data.
+2. `dataStartAt`: Start time boundary of the current forecast data points. Ignores current forecast data points before this time. Must be within the forecast data point timestamps. Defaults to the earliest time in the forecast data.
+3. `dataEndAt`: End time boundary of the current forecast data points. Ignores current forecast data points after this time. Must be within the forecast data point timestamps.Defaults to the latest time in the forecast data.
 If neither `dataStartAt` nor `dataEndAt` are provided, all forecasted data points are used in calculating the optimal marginal carbon intensity window.
 4. `windowSize`: The estimated duration (in minutes) of the workload. Defaults to the duration of a single forecast data point.
 

--- a/src/CarbonAware.WebApi/src/README.md
+++ b/src/CarbonAware.WebApi/src/README.md
@@ -170,7 +170,7 @@ This endpoint is useful for determining if there is a more carbon-optimal time t
 Parameters:
 1. `location`: This is a required parameter and is an array of the names of the data region for the configured Cloud provider.
 2. `dataStartAt`: Start time boundary of the current forecast data points. Ignores current forecast data points before this time. Must be within the forecast data point timestamps. Defaults to the earliest time in the forecast data.
-3. `dataEndAt`: End time boundary of the current forecast data points. Ignores current forecast data points after this time. Must be within the forecast data point timestamps.Defaults to the latest time in the forecast data.
+3. `dataEndAt`: End time boundary of the current forecast data points. Ignores current forecast data points after this time. Must be within the forecast data point timestamps. Defaults to the latest time in the forecast data.
 If neither `dataStartAt` nor `dataEndAt` are provided, all forecasted data points are used in calculating the optimal marginal carbon intensity window.
 4. `windowSize`: The estimated duration (in minutes) of the workload. Defaults to the duration of a single forecast data point.
 

--- a/src/CarbonAware.WebApi/src/README.md
+++ b/src/CarbonAware.WebApi/src/README.md
@@ -161,10 +161,14 @@ EG
 
 ### GET emissions/forecasts/current
 
-This endpoint fetches the most recent forecast for all provided locations and calculates the optimal marginal carbon intensity windows (per the specified windowSize) for each, within the start and end time boundaries. 
-If no start or end time boundaries are provided, all forecasted data points are used. 
+This endpoint fetches only the most recently generated forecast for all provided locations.  It filters down the full set  
+of forecasted data points using the "dataStartAt" and "dataEndAt" parameters. If no start or end time boundaries are 
+provided, all forecasted data points are used.  The data points are then used to calculate average marginal carbon 
+intensities of the specified "windowSize" and the optimal marginal carbon intensity window is identified.  
 
-The forecast data represents what the data source predicts future marginal carbon intesity values to be, not actual measured emissions data (as future values cannot be known).
+The forecast data represents what the data source predicts future marginal carbon intesity values to be, 
+not actual measured emissions data (as future values cannot be known).
+
 This endpoint is useful for determining if there is a more carbon-optimal time to use electicity predicted in the future.
 
 Parameters:

--- a/src/CarbonAware.WebApi/src/README.md
+++ b/src/CarbonAware.WebApi/src/README.md
@@ -161,10 +161,10 @@ EG
 
 ### GET emissions/forecasts/current
 
-This endpoint fetches only the most recently generated forecast for all provided locations.  It filters down the full set  
-of forecasted data points using the "dataStartAt" and "dataEndAt" parameters. If no start or end time boundaries are 
-provided, all forecasted data points are used.  The data points are then used to calculate average marginal carbon 
-intensities of the specified "windowSize" and the optimal marginal carbon intensity window is identified.  
+This endpoint fetches only the most recently generated forecast for all provided locations.  It uses the "dataStartAt" and 
+"dataEndAt" parameters to scope the forecasted data points (if available for those times). If no start or end time 
+boundaries are provided, the entire forecast dataset is used. The scoped data points are used to calculate average marginal 
+carbon intensities of the specified "windowSize" and the optimal marginal carbon intensity window is identified.
 
 The forecast data represents what the data source predicts future marginal carbon intesity values to be, 
 not actual measured emissions data (as future values cannot be known).
@@ -188,6 +188,7 @@ EG
 ```
 [
   {
+    "requestedAt": "2022-07-19T13:37:49+00:00",
     "generatedAt": "2022-07-19T13:35:00+00:00",
     "location": "northeurope",
     "dataStartAt": "2022-07-19T14:00:00Z",

--- a/src/CarbonAware.WebApi/src/README.md
+++ b/src/CarbonAware.WebApi/src/README.md
@@ -168,22 +168,27 @@ The forecast data represents what the data source predicts future marginal carbo
 This endpoint is useful for determining if there is a more carbon-optimal time to use electicity predicted in the future.
 
 Parameters:
-1. location: This is a required parameter and is an array of the names of the data region for the configured Cloud provider.
-2. startTime: Start time boundary of forecasted data points. Ignores current forecast data points before this time. It defaults to the earliest time in the forecast data.
-3. endTime: End time boundary of forecasted data points. Ignores current forecast data points after this time. Defaults to the latest time in the forecast data.
-If time period is not provided, it retrieves all the data until the current time.
-4. windowSize: The estimated duration (in minutes) of the workload. Defaults to the duration of a single forecast data point.
+1. `location`: This is a required parameter and is an array of the names of the data region for the configured Cloud provider.
+2. `dataStartAt`: Start time boundary of the current forecast data points. Ignores current forecast data points before this time. It defaults to the earliest time in the forecast data.
+3. `dataEndAt`: End time boundary of the current forecast data points. Ignores current forecast data points after this time. Defaults to the latest time in the forecast data.
+If neither `dataStartAt` nor `dataEndAt` are provided, all forecasted data points are used in calculating the optimal marginal carbon intensity window.
+4. `windowSize`: The estimated duration (in minutes) of the workload. Defaults to the duration of a single forecast data point.
 
 EG
 ```
-https://<server_name>/emissions/forecasts/current?location=northeurope&startTime=2022-07-19T14:00:00.000Z&endTime=2022-07-20T04:38:00.000Z&windowSize=10
+https://<server_name>/emissions/forecasts/current?location=northeurope&dataStartAt=2022-07-19T14:00:00Z&dataEndAt=2022-07-20T04:38:00Z&windowSize=10
 ```
 The response is an array of forecasts (one per requested location) with their optimal marginal carbon intensity windows.
+
 EG
 ```
 [
   {
     "generatedAt": "2022-07-19T13:35:00+00:00",
+    "location": "northeurope",
+    "dataStartAt": "2022-07-19T14:00:00Z",
+    "dataEndAt": "2022-07-20T04:38:00Z",
+    "windowSize": 10,
     "optimalDataPoint": {
       "location": "IE",
       "timestamp": "2022-07-19T18:45:00+00:00",
@@ -193,17 +198,17 @@ EG
     "forecastData": [
       {
         "location": "IE",
-        "timestamp": "2022-07-19T13:55:00+00:00",
+        "timestamp": "2022-07-19T14:00:00+00:00",
         "duration": 10,
         "value": 532.02293146
       },
+      ...
       {
         "location": "IE",
-        "timestamp": "2022-07-19T14:00:00+00:00",
+        "timestamp": "2022-07-20T04:25:00+00:00",
         "duration": 10,
         "value": 535.7318741001667
-      },
-      ..
+      }
     ]
   }
 ]

--- a/src/CarbonAware.WebApi/test/integrationTests/CarbonAwareControllerTests.cs
+++ b/src/CarbonAware.WebApi/test/integrationTests/CarbonAwareControllerTests.cs
@@ -124,8 +124,8 @@ public class CarbonAwareControllerTests : IntegrationTestingBase
         // A valid region name is required: 'location' is not specifically under test.
         queryStrings["location"] = "westus";
         // Mock data setup is set to current date.  This date will always be in the past.
-        queryStrings["startTime"] = "1999-01-01T00:00:00Z";
-        queryStrings["endTime"] = "1999-01-02T00:00:00Z";
+        queryStrings["dataStartAt"] = "1999-01-01T00:00:00Z";
+        queryStrings["dataEndAt"] = "1999-01-02T00:00:00Z";
 
         var endpointURI = ConstructUriWithQueryString(currentForecastURI, queryStrings);
 

--- a/src/CarbonAware.WebApi/test/unitTests/models/EmissionsForecastDTOTests.cs
+++ b/src/CarbonAware.WebApi/test/unitTests/models/EmissionsForecastDTOTests.cs
@@ -22,8 +22,8 @@ public class EmissionsForecastDTOTests
         {
             GeneratedAt = expectedGeneratedAt,
             Location = new Location(){ LocationType = LocationType.CloudProvider, RegionName = expectedLocationName },
-            StartTime =  expectedStartTime,
-            EndTime =  expectedEndTime,
+            DataStartAt =  expectedStartTime,
+            DataEndAt =  expectedEndTime,
             WindowSize = TimeSpan.FromMinutes(expectedWindowSize),
             ForecastData = new List<EmissionsData>(){ new EmissionsData(){ Rating = expectedDataPointValue } },
             OptimalDataPoint = new EmissionsData(){ Rating = expectedOptimalValue }
@@ -34,8 +34,8 @@ public class EmissionsForecastDTOTests
 
         Assert.AreEqual(expectedGeneratedAt, emissionsForecastDTO.GeneratedAt);
         Assert.AreEqual(expectedLocationName, emissionsForecastDTO.Location);
-        Assert.AreEqual(expectedStartTime, emissionsForecastDTO.StartTime);
-        Assert.AreEqual(expectedEndTime, emissionsForecastDTO.EndTime);
+        Assert.AreEqual(expectedStartTime, emissionsForecastDTO.DataStartAt);
+        Assert.AreEqual(expectedEndTime, emissionsForecastDTO.DataEndAt);
         Assert.AreEqual(expectedWindowSize, emissionsForecastDTO.WindowSize);
         Assert.AreEqual(expectedOptimalValue, emissionsForecastDTO.OptimalDataPoint?.Value);
         Assert.AreEqual(1, emissionsDataDTO?.Count());

--- a/src/CarbonAware/src/Model/EmissionsForecast.cs
+++ b/src/CarbonAware/src/Model/EmissionsForecast.cs
@@ -17,12 +17,12 @@ public record EmissionsForecast
     /// <summary>
     /// Gets or sets the start time of the forecast data points.
     /// </summary>
-    public DateTimeOffset StartTime { get; set; }
+    public DateTimeOffset DataStartAt { get; set; }
 
     /// <summary>
     /// Gets or sets the end time of the forecast data points.
     /// </summary>
-    public DateTimeOffset EndTime { get; set; }
+    public DateTimeOffset DataEndAt { get; set; }
 
     /// <summary>
     /// Gets or sets rolling average window duration.
@@ -48,19 +48,19 @@ public record EmissionsForecast
         var minTime = firstDataPoint.Time;
         var maxTime = lastDataPoint.Time + lastDataPoint.Duration;
 
-        if (StartTime >= EndTime)
+        if (DataStartAt >= DataEndAt)
         {
-            AddErrorMessage(errors, "startTime", "startTime must be earlier than endTime");
+            AddErrorMessage(errors, "dataStartAt", "dataStartAt must be earlier than dataEndAt");
         }
 
-        if (StartTime < minTime || StartTime > maxTime)
+        if (DataStartAt < minTime || DataStartAt > maxTime)
         {
-            AddErrorMessage(errors, "startTime", $"startTime must be within time range of the forecasted data, '{minTime}' through '{maxTime}'");
+            AddErrorMessage(errors, "dataStartAt", $"dataStartAt must be within time range of the forecasted data, '{minTime}' through '{maxTime}'");
         }
 
-        if (EndTime < minTime || EndTime > maxTime)
+        if (DataEndAt < minTime || DataEndAt > maxTime)
         {
-            AddErrorMessage(errors, "endTime", $"endTime must be within time range of the forecasted data, '{minTime}' through '{maxTime}'");
+            AddErrorMessage(errors, "dataEndAt", $"dataEndAt must be within time range of the forecasted data, '{minTime}' through '{maxTime}'");
         }
 
         if (errors.Keys.Count > 0)


### PR DESCRIPTION
Issue Number: 462

## Summary
Update forecast params to clearly indicate relationship to forecast data.

## Changes

- `startTime` -> `dataStartAt`
- `endTime` -> `dataEndAt`
- `requestedAt` added to response objects
- Updated documentation language for clarity.

## Checklist

- [x] Local Tests Passing?
- [x] CICD and Pipeline Tests Passing?
- [x] Added any new Tests?
- [x] Documentation Updates Made?
- [x] I have documented API changes (if any).
- [x] I have documented breaking changes (if any).

## Are there API Changes? YES
If yes, what are the expected API Changes? Please link to an API-Comparison workflow with the API Diff.

https://github.com/microsoft/carbon-aware-sdk/runs/7455978986?check_suite_focus=true#step:11:13

## Is this a breaking change? YES

Users of the `/emissions/forecasts/current` endpoint will need to update the query params used for scoping forecast data:
- `startTime` -> `dataStartAt`
- `endTime` -> `dataEndAt`
