### PR TITLE
Update WattTimeDataSourceTests to verify GeneratedAt

### DIFF
--- a/src/CarbonAware.DataSources/CarbonAware.DataSources.WattTime/test/WattTimeDataSourceTests.cs
+++ b/src/CarbonAware.DataSources/CarbonAware.DataSources.WattTime/test/WattTimeDataSourceTests.cs
@@ -289,8 +289,9 @@ public class WattTimeDataSourceTests
 
         // Assert
         Assert.IsNotNull(result);
-        Assert.AreEqual(result.RequestedAt, requestedAt);
-        Assert.AreEqual(result.GeneratedAt, expectedAt);
+        Assert.AreEqual(requestedAt, result.RequestedAt);
+        this.WattTimeClient.Verify(w => w.GetForecastOnDateAsync(
+            It.IsAny<BalancingAuthority>(), It.Is<DateTimeOffset>(date => date.Equals(expectedAt))), Times.Once);
     }
 
 


### PR DESCRIPTION
Issue Number: 528

## Summary
Fast-follow to unit test `generatedAt`

## Changes

`Assert.AreEqual(result.GeneratedAt, expectedAt);` will always pass because it is asserting a value that we hardcode in the test.

Update to use `Mock.Verify` to assert that we call WattTime with the expected rounded date.

## Checklist

- [x] Local Tests Passing? Yes
- [x] CICD and Pipeline Tests Passing? Yes
- [x] Added any new Tests? Yes
- [x] Documentation Updates Made? No
- [x] Are there any API Changes? No
- [x] This is not a breaking change. If it is, please describe it below.
