### PR TITLE
513/handle null frequencies

### DIFF
--- a/src/CarbonAware.DataSources/CarbonAware.DataSources.WattTime/src/WattTimeDataSource.cs
+++ b/src/CarbonAware.DataSources/CarbonAware.DataSources.WattTime/src/WattTimeDataSource.cs
@@ -164,6 +164,8 @@ public class WattTimeDataSource : ICarbonIntensityDataSource
         var first = firstPoint ?? throw new WattTimeClientException("Too few data points returned"); 
         var second = secondPoint ?? throw new WattTimeClientException("Too few data points returned");
 
+        // Handle chronological and reverse-chronological data by using `.Duration()` to get
+        // the absolute value of TimeSpan between the two points.
         return (first.PointTime - second.PointTime).Duration();
     }
 

--- a/src/CarbonAware.DataSources/CarbonAware.DataSources.WattTime/src/WattTimeDataSource.cs
+++ b/src/CarbonAware.DataSources/CarbonAware.DataSources.WattTime/src/WattTimeDataSource.cs
@@ -166,7 +166,7 @@ public class WattTimeDataSource : ICarbonIntensityDataSource
 
         // Handle chronological and reverse-chronological data by using `.Duration()` to get
         // the absolute value of the TimeSpan between the two points.
-        return (first.PointTime - second.PointTime).Duration();
+        return first.PointTime.Subtract(second.PointTime).Duration();
     }
 
     private TimeSpan GetDurationFromGridEmissionDataPointsOrDefault(IEnumerable<GridEmissionDataPoint> gridEmissionDataPoints, TimeSpan defaultValue)

--- a/src/CarbonAware.DataSources/CarbonAware.DataSources.WattTime/src/WattTimeDataSource.cs
+++ b/src/CarbonAware.DataSources/CarbonAware.DataSources.WattTime/src/WattTimeDataSource.cs
@@ -181,7 +181,7 @@ public class WattTimeDataSource : ICarbonIntensityDataSource
 
     private TimeSpan FrequencyToTimeSpanOrDefault(int? frequency, TimeSpan defaultValue)
     {
-       return (frequency != null) ? TimeSpan.FromSeconds((double)frequency) : defaultValue;
+        return (frequency != null) ? TimeSpan.FromSeconds((double)frequency) : defaultValue;
     }
 
     private async Task<BalancingAuthority> GetBalancingAuthority(Location location, Activity? activity)

--- a/src/CarbonAware.DataSources/CarbonAware.DataSources.WattTime/src/WattTimeDataSource.cs
+++ b/src/CarbonAware.DataSources/CarbonAware.DataSources.WattTime/src/WattTimeDataSource.cs
@@ -164,8 +164,6 @@ public class WattTimeDataSource : ICarbonIntensityDataSource
         var first = firstPoint ?? throw new WattTimeClientException("Too few data points returned"); 
         var second = secondPoint ?? throw new WattTimeClientException("Too few data points returned");
 
-        // Handle chronological and reverse-chronological data by using `.Duration()` to get
-        // the absolute value of TimeSpan between the two points.
         return (first.PointTime - second.PointTime).Duration();
     }
 

--- a/src/CarbonAware.DataSources/CarbonAware.DataSources.WattTime/src/WattTimeDataSource.cs
+++ b/src/CarbonAware.DataSources/CarbonAware.DataSources.WattTime/src/WattTimeDataSource.cs
@@ -164,6 +164,8 @@ public class WattTimeDataSource : ICarbonIntensityDataSource
         var first = firstPoint ?? throw new WattTimeClientException("Too few data points returned"); 
         var second = secondPoint ?? throw new WattTimeClientException("Too few data points returned");
 
+        // Handle chronological and reverse-chronological data by using `.Duration()` to get
+        // the absolute value of the TimeSpan between the two points.
         return (first.PointTime - second.PointTime).Duration();
     }
 

--- a/src/CarbonAware.DataSources/CarbonAware.DataSources.WattTime/test/WattTimeDataSourceTests.cs
+++ b/src/CarbonAware.DataSources/CarbonAware.DataSources.WattTime/test/WattTimeDataSourceTests.cs
@@ -293,7 +293,6 @@ public class WattTimeDataSourceTests
         Assert.AreEqual(result.GeneratedAt, expectedAt);
     }
 
-
     [DatapointSource]
     public float[] moerValues = new float[] { 0.0F, 10.0F, 100.0F, 1000.0F, 596.1367F};
 

--- a/src/CarbonAware.DataSources/CarbonAware.DataSources.WattTime/test/WattTimeDataSourceTests.cs
+++ b/src/CarbonAware.DataSources/CarbonAware.DataSources.WattTime/test/WattTimeDataSourceTests.cs
@@ -56,7 +56,7 @@ public class WattTimeDataSourceTests
     public async Task GetCarbonIntensity_ReturnsResultsWhenRecordsFound()
     {
         var startDate = this.DefaultDataStartTime;
-        var endDate = new DateTimeOffset(2022, 4, 18, 12, 33, 42, TimeSpan.FromHours(-6));
+        var endDate = startDate.AddMinutes(1);
         var lbsPerMwhEmissions = 10;
         var gPerKwhEmissions = this.DataSource.ConvertMoerToGramsPerKilowattHour(lbsPerMwhEmissions);
 
@@ -86,7 +86,7 @@ public class WattTimeDataSourceTests
     public async Task GetCarbonIntensity_ReturnsEmptyListWhenNoRecordsFound()
     {
         var startDate = new DateTimeOffset(2022, 4, 18, 12, 32, 42, TimeSpan.FromHours(-6));
-        var endDate = new DateTimeOffset(2022, 4, 18, 12, 33, 42, TimeSpan.FromHours(-6));
+        var endDate = startDate.AddMinutes(1);
 
         this.WattTimeClient.Setup(w => w.GetDataAsync(
             this.DefaultBalancingAuthority,
@@ -104,7 +104,7 @@ public class WattTimeDataSourceTests
     public void GetCarbonIntensity_ThrowsWhenRegionNotFound()
     {
         var startDate = new DateTimeOffset(2022, 4, 18, 12, 32, 42, TimeSpan.FromHours(-6));
-        var endDate = new DateTimeOffset(2022, 4, 18, 12, 33, 42, TimeSpan.FromHours(-6));
+        var endDate = startDate.AddMinutes(1);
 
         this.LocationSource.Setup(l => l.ToGeopositionLocationAsync(this.DefaultLocation)).Throws<LocationConversionException>();
 
@@ -117,7 +117,7 @@ public class WattTimeDataSourceTests
     {
         // Arrange
         var startDate = this.DefaultDataStartTime;
-        var endDate = new DateTimeOffset(2022, 4, 18, 12, 33, 42, TimeSpan.FromHours(-6));
+        var endDate = startDate.AddMinutes(1);
         var generatedAt = new DateTimeOffset(2022, 4, 18, 12, 30, 00, TimeSpan.FromHours(-6));
         var lbsPerMwhEmissions = 10;
         var gPerKwhEmissions = this.DataSource.ConvertMoerToGramsPerKilowattHour(lbsPerMwhEmissions);
@@ -181,7 +181,7 @@ public class WattTimeDataSourceTests
     }
 
     [Test]
-    public void GetCarbonIntensityForecastAsync_ThrowsWhenNoForecastFoundForReuqestedTime()
+    public void GetCarbonIntensityForecastAsync_ThrowsWhenNoForecastFoundForRequestedTime()
     {
         var generatedAt = new DateTimeOffset();
 
@@ -259,11 +259,12 @@ public class WattTimeDataSourceTests
     [TestCase(new double[] { 0 }, null, TestName = "GetCarbonIntensity - for less than 2 data points, frequency is null for one data point ")]
     [TestCase(new double[] { 300, 300 }, null, null, TestName = "GetCarbonIntensity - for multiple data points, frequency is null for all data points")]
     [TestCase(new double[] { 500 }, 500, TestName = "GetCarbonIntensity - frequency is not null")]
+    [TestCase(new double[] { }, TestName = "GetCarbonIntensity - for zero data points, returns empty enumerable")]
     public async Task GetCarbonIntensity_CalculatesDurationBasedOnFrequency(double[] durationValues, params int?[] frequencyValues)
     {
         // Arrange
         var startDate = this.DefaultDataStartTime;
-        var endDate = new DateTimeOffset(2022, 4, 18, 12, 50, 00, TimeSpan.FromHours(-6));
+        var endDate = startDate.AddMinutes(10);
         var emissionData = GenerateDataPoints(frequencyValues.Length);
         for( int i = 0; i < frequencyValues.Length; i++)
         {
@@ -290,10 +291,10 @@ public class WattTimeDataSourceTests
     private void MockBalancingAuthorityLocationMapping()
     {
         this.LocationSource.Setup(r => r.ToGeopositionLocationAsync(this.DefaultLocation)).Returns(Task.FromResult(this.DefaultLocation));
-        var latitude = this.DefaultLocation.Latitude.ToString() ?? throw new ArgumentNullException(String.Format("Could not find location"));
-        var longitude = this.DefaultLocation.Longitude.ToString() ?? throw new ArgumentNullException(String.Format("Could not find location"));
+        var latitude = this.DefaultLocation.Latitude.ToString();
+        var longitude = this.DefaultLocation.Longitude.ToString();
 
-        this.WattTimeClient.Setup(w => w.GetBalancingAuthorityAsync(latitude, longitude)
+        this.WattTimeClient.Setup(w => w.GetBalancingAuthorityAsync(latitude!, longitude!)
         ).ReturnsAsync(() => this.DefaultBalancingAuthority);
     }
 

--- a/src/CarbonAware.DataSources/CarbonAware.DataSources.WattTime/test/WattTimeDataSourceTests.cs
+++ b/src/CarbonAware.DataSources/CarbonAware.DataSources.WattTime/test/WattTimeDataSourceTests.cs
@@ -285,7 +285,6 @@ public class WattTimeDataSourceTests
 
         // Act
         var result = await this.DataSource.GetCarbonIntensityForecastAsync(location, requestedAt);
-        
 
         // Assert
         Assert.IsNotNull(result);

--- a/src/CarbonAware.DataSources/CarbonAware.DataSources.WattTime/test/WattTimeDataSourceTests.cs
+++ b/src/CarbonAware.DataSources/CarbonAware.DataSources.WattTime/test/WattTimeDataSourceTests.cs
@@ -336,11 +336,11 @@ public class WattTimeDataSourceTests
         var emissions = new List<GridEmissionDataPoint>();
         var start = startDate;
 
-        for (var i = 0; i < frequencyValues.Count(); i++)
+        foreach (var frequency in frequencyValues)
         {
             emissions.Add(new GridEmissionDataPoint()
             {
-                Frequency = (frequencyValues[i] == null ? null : (int)frequencyValues[i]),
+                Frequency = (frequency == null?null:Convert.ToInt32(frequency)),
                 PointTime = start
             });
             start = start + TimeSpan.FromMinutes(5);

--- a/src/CarbonAware.DataSources/CarbonAware.DataSources.WattTime/test/WattTimeDataSourceTests.cs
+++ b/src/CarbonAware.DataSources/CarbonAware.DataSources.WattTime/test/WattTimeDataSourceTests.cs
@@ -56,7 +56,7 @@ public class WattTimeDataSourceTests
     public async Task GetCarbonIntensity_ReturnsResultsWhenRecordsFound()
     {
         var startDate = this.DefaultDataStartTime;
-        var endDate = new DateTimeOffset(2022, 4, 18, 12, 33, 42, TimeSpan.FromHours(-6));
+        var endDate = startDate.AddMinutes(1);
         var lbsPerMwhEmissions = 10;
         var gPerKwhEmissions = this.DataSource.ConvertMoerToGramsPerKilowattHour(lbsPerMwhEmissions);
 
@@ -86,7 +86,7 @@ public class WattTimeDataSourceTests
     public async Task GetCarbonIntensity_ReturnsEmptyListWhenNoRecordsFound()
     {
         var startDate = new DateTimeOffset(2022, 4, 18, 12, 32, 42, TimeSpan.FromHours(-6));
-        var endDate = new DateTimeOffset(2022, 4, 18, 12, 33, 42, TimeSpan.FromHours(-6));
+        var endDate = startDate.AddMinutes(1);
 
         this.WattTimeClient.Setup(w => w.GetDataAsync(
             this.DefaultBalancingAuthority,
@@ -104,7 +104,7 @@ public class WattTimeDataSourceTests
     public void GetCarbonIntensity_ThrowsWhenRegionNotFound()
     {
         var startDate = new DateTimeOffset(2022, 4, 18, 12, 32, 42, TimeSpan.FromHours(-6));
-        var endDate = new DateTimeOffset(2022, 4, 18, 12, 33, 42, TimeSpan.FromHours(-6));
+        var endDate = startDate.AddMinutes(1);
 
         this.LocationSource.Setup(l => l.ToGeopositionLocationAsync(this.DefaultLocation)).Throws<LocationConversionException>();
 
@@ -117,7 +117,7 @@ public class WattTimeDataSourceTests
     {
         // Arrange
         var startDate = this.DefaultDataStartTime;
-        var endDate = new DateTimeOffset(2022, 4, 18, 12, 33, 42, TimeSpan.FromHours(-6));
+        var endDate = startDate.AddMinutes(1);
         var generatedAt = new DateTimeOffset(2022, 4, 18, 12, 30, 00, TimeSpan.FromHours(-6));
         var lbsPerMwhEmissions = 10;
         var gPerKwhEmissions = this.DataSource.ConvertMoerToGramsPerKilowattHour(lbsPerMwhEmissions);
@@ -259,11 +259,12 @@ public class WattTimeDataSourceTests
     [TestCase(new double[] { 0 }, null, TestName = "GetCarbonIntensity - for less than 2 data points, frequency is null for one data point ")]
     [TestCase(new double[] { 300, 300 }, null, null, TestName = "GetCarbonIntensity - for multiple data points, frequency is null for all data points")]
     [TestCase(new double[] { 500 }, 500, TestName = "GetCarbonIntensity - frequency is not null")]
+    [TestCase(new double[] { }, TestName = "GetCarbonIntensity - for zero data points, returns empty enumerable")]
     public async Task GetCarbonIntensity_CalculatesDurationBasedOnFrequency(double[] durationValues, params int?[] frequencyValues)
     {
         // Arrange
         var startDate = this.DefaultDataStartTime;
-        var endDate = new DateTimeOffset(2022, 4, 18, 12, 50, 00, TimeSpan.FromHours(-6));
+        var endDate = startDate.AddMinutes(10);
         var emissionData = GenerateDataPoints(frequencyValues.Length);
         for( int i = 0; i < frequencyValues.Length; i++)
         {
@@ -290,10 +291,10 @@ public class WattTimeDataSourceTests
     private void MockBalancingAuthorityLocationMapping()
     {
         this.LocationSource.Setup(r => r.ToGeopositionLocationAsync(this.DefaultLocation)).Returns(Task.FromResult(this.DefaultLocation));
-        var latitude = this.DefaultLocation.Latitude.ToString() ?? throw new ArgumentNullException(String.Format("Could not find location"));
-        var longitude = this.DefaultLocation.Longitude.ToString() ?? throw new ArgumentNullException(String.Format("Could not find location"));
+        var latitude = this.DefaultLocation.Latitude.ToString();
+        var longitude = this.DefaultLocation.Longitude.ToString();
 
-        this.WattTimeClient.Setup(w => w.GetBalancingAuthorityAsync(latitude, longitude)
+        this.WattTimeClient.Setup(w => w.GetBalancingAuthorityAsync(latitude!, longitude!)
         ).ReturnsAsync(() => this.DefaultBalancingAuthority);
     }
 

--- a/src/CarbonAware.DataSources/CarbonAware.DataSources.WattTime/test/WattTimeDataSourceTests.cs
+++ b/src/CarbonAware.DataSources/CarbonAware.DataSources.WattTime/test/WattTimeDataSourceTests.cs
@@ -24,6 +24,9 @@ public class WattTimeDataSourceTests
     private WattTimeDataSource DataSource { get; set; }
 
     private Mock<ILocationSource> LocationSource { get; set; }
+    private Location DefaultLocation { get; set; }
+    private BalancingAuthority DefaultBalancingAuthority { get; set; }
+    private DateTimeOffset DefaultDataStartTime { get; set; }
 
     // Magic floating point tolerance to allow for minuscule differences in floating point arithmetic.
     private const double FLOATING_POINT_TOLERANCE = 0.00000001;
@@ -41,37 +44,32 @@ public class WattTimeDataSourceTests
         this.LocationSource = new Mock<ILocationSource>();
 
         this.DataSource = new WattTimeDataSource(this.Logger.Object, this.WattTimeClient.Object, this.LocationSource.Object);
+
+        this.DefaultLocation = new Location() { RegionName = "eastus", LocationType = LocationType.CloudProvider, CloudProvider = CloudProvider.Azure };
+        this.DefaultBalancingAuthority = new BalancingAuthority() { Abbreviation = "BA" };
+        this.DefaultDataStartTime = new DateTimeOffset(2022, 4, 18, 12, 32, 42, TimeSpan.FromHours(-6));
+        MockBalancingAuthorityLocationMapping();
     }
 
     [Test]
     [DefaultFloatingPointTolerance(FLOATING_POINT_TOLERANCE)]
     public async Task GetCarbonIntensity_ReturnsResultsWhenRecordsFound()
     {
-        var location = new Location() { RegionName = "eastus", LocationType = LocationType.CloudProvider, CloudProvider = CloudProvider.Azure };
-        var balancingAuthority = new BalancingAuthority() { Abbreviation = "BA" };
-        var startDate = new DateTimeOffset(2022, 4, 18, 12, 32, 42, TimeSpan.FromHours(-6));
+        var startDate = this.DefaultDataStartTime;
         var endDate = new DateTimeOffset(2022, 4, 18, 12, 33, 42, TimeSpan.FromHours(-6));
         var lbsPerMwhEmissions = 10;
         var gPerKwhEmissions = this.DataSource.ConvertMoerToGramsPerKilowattHour(lbsPerMwhEmissions);
 
-        var emissionData = new List<GridEmissionDataPoint>()
-        {
-            new GridEmissionDataPoint()
-            {
-                BalancingAuthorityAbbreviation = balancingAuthority.Abbreviation,
-                PointTime = startDate,
-                Value = lbsPerMwhEmissions,
-            }
-        };
+        var emissionData = GenerateDataPoints(new int?[1], lbsPerMwhEmissions);
 
         this.WattTimeClient.Setup(w => w.GetDataAsync(
-            balancingAuthority,
+            this.DefaultBalancingAuthority,
             It.IsAny<DateTimeOffset>(),
             It.IsAny<DateTimeOffset>())
         ).ReturnsAsync(() => emissionData);
 
-        SetupBalancingAuthority(balancingAuthority, location);
-        var result = await this.DataSource.GetCarbonIntensityAsync(new List<Location>() { location }, startDate, endDate);
+        //SetupBalancingAuthority(balancingAuthority, location);
+        var result = await this.DataSource.GetCarbonIntensityAsync(new List<Location>() { this.DefaultLocation }, startDate, endDate);
 
         Assert.IsNotNull(result);
         Assert.AreEqual(1, result.Count());
@@ -79,29 +77,25 @@ public class WattTimeDataSourceTests
         var first = result.First();
         Assert.IsNotNull(first);
         Assert.AreEqual(gPerKwhEmissions, first.Rating);
-        Assert.AreEqual(balancingAuthority.Abbreviation, first.Location);
+        Assert.AreEqual(this.DefaultBalancingAuthority.Abbreviation, first.Location);
         Assert.AreEqual(startDate, first.Time);
 
-        this.LocationSource.Verify(r => r.ToGeopositionLocationAsync(location));
+        this.LocationSource.Verify(r => r.ToGeopositionLocationAsync(this.DefaultLocation));
     }
 
     [Test]
     public async Task GetCarbonIntensity_ReturnsEmptyListWhenNoRecordsFound()
     {
-        var location = new Location() { RegionName = "eastus", LocationType = LocationType.CloudProvider, CloudProvider = CloudProvider.Azure };
-        var balancingAuthority = new BalancingAuthority() { Abbreviation = "BA" };
         var startDate = new DateTimeOffset(2022, 4, 18, 12, 32, 42, TimeSpan.FromHours(-6));
         var endDate = new DateTimeOffset(2022, 4, 18, 12, 33, 42, TimeSpan.FromHours(-6));
 
         this.WattTimeClient.Setup(w => w.GetDataAsync(
-            balancingAuthority,
+            this.DefaultBalancingAuthority,
             startDate,
             endDate)
         ).ReturnsAsync(() => new List<GridEmissionDataPoint>());
 
-        SetupBalancingAuthority(balancingAuthority, location);
-
-        var result = await this.DataSource.GetCarbonIntensityAsync(new List<Location>() { location }, startDate, endDate);
+        var result = await this.DataSource.GetCarbonIntensityAsync(new List<Location>() { this.DefaultLocation }, startDate, endDate);
 
         Assert.IsNotNull(result);
         Assert.AreEqual(0, result.Count());
@@ -110,13 +104,12 @@ public class WattTimeDataSourceTests
     [Test]
     public void GetCarbonIntensity_ThrowsWhenRegionNotFound()
     {
-        var location = new Location() { RegionName = "eastus", LocationType = LocationType.CloudProvider, CloudProvider = CloudProvider.Azure };
         var startDate = new DateTimeOffset(2022, 4, 18, 12, 32, 42, TimeSpan.FromHours(-6));
         var endDate = new DateTimeOffset(2022, 4, 18, 12, 33, 42, TimeSpan.FromHours(-6));
 
-        this.LocationSource.Setup(l => l.ToGeopositionLocationAsync(location)).Throws<LocationConversionException>();
+        this.LocationSource.Setup(l => l.ToGeopositionLocationAsync(this.DefaultLocation)).Throws<LocationConversionException>();
 
-        Assert.ThrowsAsync<LocationConversionException>(async () => await this.DataSource.GetCarbonIntensityAsync(new List<Location>() { location }, startDate, endDate));
+        Assert.ThrowsAsync<LocationConversionException>(async () => await this.DataSource.GetCarbonIntensityAsync(new List<Location>() { this.DefaultLocation }, startDate, endDate));
     }
 
     [TestCase(true, TestName = "Getting current forecast")]
@@ -124,127 +117,100 @@ public class WattTimeDataSourceTests
     public async Task GetCarbonIntensityForecastAsync_ReturnsResultsWhenRecordsFound(bool getCurrentForecast)
     {
         // Arrange
-        var location = new Location() { RegionName = "eastus", LocationType = LocationType.CloudProvider, CloudProvider = CloudProvider.Azure };
-        var balancingAuthority = new BalancingAuthority() { Abbreviation = "BA" };
-        var generatedAt = new DateTimeOffset(2022, 4, 18, 12, 30, 00, TimeSpan.FromHours(-6));
-        var startDate = new DateTimeOffset(2022, 4, 18, 12, 32, 42, TimeSpan.FromHours(-6));
+        var startDate = this.DefaultDataStartTime;
         var endDate = new DateTimeOffset(2022, 4, 18, 12, 33, 42, TimeSpan.FromHours(-6));
+        var generatedAt = new DateTimeOffset(2022, 4, 18, 12, 30, 00, TimeSpan.FromHours(-6));
         var lbsPerMwhEmissions = 10;
         var gPerKwhEmissions = this.DataSource.ConvertMoerToGramsPerKilowattHour(lbsPerMwhEmissions);
         var expectedDuration = TimeSpan.FromMinutes(5);
 
-        var emissionData = new List<GridEmissionDataPoint>()
-        {
-            new GridEmissionDataPoint()
-            {
-                BalancingAuthorityAbbreviation = balancingAuthority.Abbreviation,
-                PointTime = startDate,
-                Value = lbsPerMwhEmissions,
-            },
-            new GridEmissionDataPoint()
-            {
-                BalancingAuthorityAbbreviation = balancingAuthority.Abbreviation,
-                PointTime = startDate + expectedDuration,
-                Value = lbsPerMwhEmissions,
-            },
-        };
+        var emissionData = GenerateDataPoints(new int?[2], lbsPerMwhEmissions);
         var forecast = new Forecast()
         {
             GeneratedAt = generatedAt,
             ForecastData = emissionData
         };
 
-        SetupBalancingAuthority(balancingAuthority, location);
         EmissionsForecast result;
 
         if (getCurrentForecast)
         {
-            this.WattTimeClient.Setup(w => w.GetCurrentForecastAsync(balancingAuthority)
+            this.WattTimeClient.Setup(w => w.GetCurrentForecastAsync(this.DefaultBalancingAuthority)
                 ).ReturnsAsync(() => forecast);
 
             // Act
-            result = await this.DataSource.GetCurrentCarbonIntensityForecastAsync(location);
+            result = await this.DataSource.GetCurrentCarbonIntensityForecastAsync(this.DefaultLocation);
         }
         else
         {
-            this.WattTimeClient.Setup(w => w.GetForecastOnDateAsync(balancingAuthority, generatedAt)
+            this.WattTimeClient.Setup(w => w.GetForecastOnDateAsync(this.DefaultBalancingAuthority, generatedAt)
                 ).ReturnsAsync(() => forecast);
 
             // Act
-            result = await this.DataSource.GetCarbonIntensityForecastAsync(location, generatedAt);
+            result = await this.DataSource.GetCarbonIntensityForecastAsync(this.DefaultLocation, generatedAt);
         }
 
         // Assert
         Assert.IsNotNull(result);
         Assert.AreEqual(generatedAt, result.GeneratedAt);
-        Assert.AreEqual(location, result.Location);
+        Assert.AreEqual(this.DefaultLocation, result.Location);
 
         var firstDataPoint = result.ForecastData.First();
         var lastDataPoint = result.ForecastData.Last();
         Assert.IsNotNull(firstDataPoint);
         Assert.AreEqual(gPerKwhEmissions, firstDataPoint.Rating);
-        Assert.AreEqual(balancingAuthority.Abbreviation, firstDataPoint.Location);
+        Assert.AreEqual(this.DefaultBalancingAuthority.Abbreviation, firstDataPoint.Location);
         Assert.AreEqual(startDate, firstDataPoint.Time);
         Assert.AreEqual(expectedDuration, firstDataPoint.Duration);
 
         Assert.IsNotNull(lastDataPoint);
         Assert.AreEqual(gPerKwhEmissions, lastDataPoint.Rating);
-        Assert.AreEqual(balancingAuthority.Abbreviation, lastDataPoint.Location);
+        Assert.AreEqual(this.DefaultBalancingAuthority.Abbreviation, lastDataPoint.Location);
         Assert.AreEqual(startDate + expectedDuration, lastDataPoint.Time);
         Assert.AreEqual(expectedDuration, lastDataPoint.Duration);
 
-        this.LocationSource.Verify(r => r.ToGeopositionLocationAsync(location));
+        this.LocationSource.Verify(r => r.ToGeopositionLocationAsync(this.DefaultLocation));
     }
 
     [Test]
     public void GetCarbonIntensityForecastAsync_ThrowsWhenRegionNotFound()
     {
-        var location = new Location() { RegionName = "eastus", LocationType = LocationType.CloudProvider, CloudProvider = CloudProvider.Azure };
+        this.LocationSource.Setup(l => l.ToGeopositionLocationAsync(this.DefaultLocation)).Throws<LocationConversionException>();
 
-        this.LocationSource.Setup(l => l.ToGeopositionLocationAsync(location)).Throws<LocationConversionException>();
-
-        Assert.ThrowsAsync<LocationConversionException>(async () => await this.DataSource.GetCurrentCarbonIntensityForecastAsync(location));
-        Assert.ThrowsAsync<LocationConversionException>(async () => await this.DataSource.GetCarbonIntensityForecastAsync(location, new DateTimeOffset()));
+        Assert.ThrowsAsync<LocationConversionException>(async () => await this.DataSource.GetCurrentCarbonIntensityForecastAsync(this.DefaultLocation));
+        Assert.ThrowsAsync<LocationConversionException>(async () => await this.DataSource.GetCarbonIntensityForecastAsync(this.DefaultLocation, new DateTimeOffset()));
     }
 
     [Test]
     public void GetCarbonIntensityForecastAsync_ThrowsWhenNoForecastFoundForReuqestedTime()
     {
-        var location = new Location() { RegionName = "eastus", LocationType = LocationType.CloudProvider, CloudProvider = CloudProvider.Azure };
-        var balancingAuthority = new BalancingAuthority() { Abbreviation = "BA" };
         var generatedAt = new DateTimeOffset();
-        SetupBalancingAuthority(balancingAuthority, location);
 
-        this.WattTimeClient.Setup(w => w.GetForecastOnDateAsync(balancingAuthority, generatedAt)).Returns(Task.FromResult<Forecast?>(null));
+        this.WattTimeClient.Setup(w => w.GetForecastOnDateAsync(this.DefaultBalancingAuthority, generatedAt)).Returns(Task.FromResult<Forecast?>(null));
 
         // The datasource throws an exception if no forecasts are found at the requested generatedAt time.  
-        Assert.ThrowsAsync<ArgumentException>(async () => await this.DataSource.GetCarbonIntensityForecastAsync(location, generatedAt));
+        Assert.ThrowsAsync<ArgumentException>(async () => await this.DataSource.GetCarbonIntensityForecastAsync(this.DefaultLocation, generatedAt));
     }
 
-    [TestCase(0, TestName = "No datapoints")]
-    [TestCase(1, TestName = "1 datapoint")]
+    [TestCase(0, TestName = "GetCurrentCarbonIntensityForecastAsync throws for: No datapoints")]
+    [TestCase(1, TestName = "GetCurrentCarbonIntensityForecastAsync throws for: 1 datapoint")]
     public void GetCurrentCarbonIntensityForecastAsync_ThrowsWhenTooFewDatapointsReturned(int numDataPoints)
     {
         // Arrange
-        var location = new Location() { RegionName = "eastus", LocationType = LocationType.CloudProvider, CloudProvider = CloudProvider.Azure };
-        var balancingAuthority = new BalancingAuthority() { Abbreviation = "BA" };
-        var emissionData = new List<GridEmissionDataPoint>();
-        for (var i = 0; i < numDataPoints; i++)
-        {
-            emissionData.Add(new GridEmissionDataPoint());
-        }
+        var emissionData = GenerateDataPoints(new int?[numDataPoints]);
+
         var forecast = new Forecast()
         {
             GeneratedAt = DateTimeOffset.Now,
             ForecastData = emissionData
         };
 
-        this.WattTimeClient.Setup(w => w.GetCurrentForecastAsync(balancingAuthority)
+        this.WattTimeClient.Setup(w => w.GetCurrentForecastAsync(this.DefaultBalancingAuthority)
             ).ReturnsAsync(() => forecast);
 
-        SetupBalancingAuthority(balancingAuthority, location);
+        //SetupBalancingAuthority(balancingAuthority, location);
 
-        Assert.ThrowsAsync<WattTimeClientException>(async () => await this.DataSource.GetCurrentCarbonIntensityForecastAsync(location));
+        Assert.ThrowsAsync<WattTimeClientException>(async () => await this.DataSource.GetCurrentCarbonIntensityForecastAsync(this.DefaultLocation));
     }
 
     [TestCase("2022-01-01T00:00:00Z", "2022-01-01T00:00:00Z", TestName = "GetCarbonIntensityForecastAsync returns expected value 2022-01-01T00:00:00Z round to floor")]
@@ -253,39 +219,23 @@ public class WattTimeDataSourceTests
     public async Task GetCarbonIntensityForecastAsync_RequiredAtRounded(string requested, string expected)
     {
         // Arrange
-        var location = new Location() { RegionName = "eastus", LocationType = LocationType.CloudProvider, CloudProvider = CloudProvider.Azure };
-        var balancingAuthority = new BalancingAuthority() { Abbreviation = "BA" };
         var requestedAt = DateTimeOffset.Parse(requested);
         var expectedAt = DateTimeOffset.Parse(expected);
 
-        var emissionData = new List<GridEmissionDataPoint>()
-        {
-            new GridEmissionDataPoint()
-            {
-                BalancingAuthorityAbbreviation = balancingAuthority.Abbreviation,
-                PointTime = expectedAt,
-                Value = 10,
-            },
-            new GridEmissionDataPoint()
-            {
-                BalancingAuthorityAbbreviation = balancingAuthority.Abbreviation,
-                PointTime = expectedAt + TimeSpan.FromMinutes(5),
-                Value = 10,
-            },
-        };
+        var emissionData = GenerateDataPoints(new int?[2], startTime: requestedAt);
         var forecast = new Forecast()
         {
             GeneratedAt = expectedAt,
             ForecastData = emissionData
         };
 
-        SetupBalancingAuthority(balancingAuthority, location);
-        this.WattTimeClient.Setup(w => w.GetForecastOnDateAsync(balancingAuthority, expectedAt)
+        //SetupBalancingAuthority(balancingAuthority, location);
+        this.WattTimeClient.Setup(w => w.GetForecastOnDateAsync(this.DefaultBalancingAuthority, expectedAt)
                 ).ReturnsAsync(() => forecast);
 
         // Act
-        var result = await this.DataSource.GetCarbonIntensityForecastAsync(location, requestedAt);
-
+        var result = await this.DataSource.GetCarbonIntensityForecastAsync(this.DefaultLocation, requestedAt);
+        
         // Assert
         Assert.IsNotNull(result);
         Assert.AreEqual(result.RequestedAt, requestedAt);
@@ -309,59 +259,62 @@ public class WattTimeDataSourceTests
     /// <summary>
     /// Tests that if 'frequency' is not provided in the WattTime response of emission data, it is calculated from the first 2 data points, or defaulted to 0 if fewer than 2 data points are returned 
     /// </summary>
-    [TestCase(new double[] { 300, 300 }, new object?[] { 300, null }, TestName = "GetCarbonIntensity - for multiple data points, frequency is null for one data point ")]
-    [TestCase(new double[] { 0 }, new object?[] { null }, TestName = "GetCarbonIntensity - for less than 2 data points, frequency is null for one data point ")]
-    [TestCase(new double[] { 300, 300 }, new object?[] { null, null }, TestName = "GetCarbonIntensity - for multiple data points, frequency is null for all data points")]
-    [TestCase(new double[] { 500 }, new object?[] { 500 }, TestName = "GetCarbonIntensity - frequency is not null")]
-    public async Task GetCarbonIntensity_CalculatesDurationBasedOnFrequency(double[] durationValues, params object[] frequencyValues)
+    [TestCase(new double[] { 300, 300 }, 300, null, TestName = "GetCarbonIntensity - for multiple data points, frequency is null for one data point ")]
+    [TestCase(new double[] { 0 }, null, TestName = "GetCarbonIntensity - for less than 2 data points, frequency is null for one data point ")]
+    [TestCase(new double[] { 300, 300 }, null, null, TestName = "GetCarbonIntensity - for multiple data points, frequency is null for all data points")]
+    [TestCase(new double[] { 500 }, 500, TestName = "GetCarbonIntensity - frequency is not null")]
+    public async Task GetCarbonIntensity_CalculatesDurationBasedOnFrequency(double[] durationValues, params int?[] frequencyValues)
     {
-        var location = new Location() { RegionName = "eastus", LocationType = LocationType.CloudProvider, CloudProvider = CloudProvider.Azure };
-        var balancingAuthority = new BalancingAuthority() { Abbreviation = "BA" };
-        var startDate = new DateTimeOffset(2022, 4, 18, 12, 30, 00, TimeSpan.FromHours(-6));
+        // Arrange
+        var startDate = this.DefaultDataStartTime;
         var endDate = new DateTimeOffset(2022, 4, 18, 12, 50, 00, TimeSpan.FromHours(-6));
-
-        SetupEmissionsData(frequencyValues, startDate);
-        SetupBalancingAuthority(balancingAuthority, location);
-
-        var result = await this.DataSource.GetCarbonIntensityAsync(new List<Location>() { location }, startDate, endDate);
-
+        var emissionData = GenerateDataPoints(frequencyValues);
         List<double> expectedDurationList = durationValues.ToList<double>();
-        List<double> actualDurationList = result.Select(e => e.Duration.TotalSeconds).ToList();
-        
-        CollectionAssert.AreEqual(expectedDurationList, actualDurationList);
-    }
-
-    private void SetupEmissionsData(object[] frequencyValues, DateTimeOffset startDate)
-    {
-        var emissions = new List<GridEmissionDataPoint>();
-        var start = startDate;
-
-        foreach (var frequency in frequencyValues)
-        {
-            emissions.Add(new GridEmissionDataPoint()
-            {
-                Frequency = (frequency == null?null:Convert.ToInt32(frequency)),
-                PointTime = start
-            });
-            start = start + TimeSpan.FromMinutes(5);
-        }
 
         this.WattTimeClient.Setup(w => w.GetDataAsync(
             It.IsAny<BalancingAuthority>(),
             It.IsAny<DateTimeOffset>(),
             It.IsAny<DateTimeOffset>())
-        ).ReturnsAsync(() => emissions);
+        ).ReturnsAsync(() => emissionData);
+
+        // Act
+        var result = await this.DataSource.GetCarbonIntensityAsync(new List<Location>() { this.DefaultLocation }, startDate, endDate);
+
+        // Assert
+        List<double> actualDurationList = result.Select(e => e.Duration.TotalSeconds).ToList();
+        
+        CollectionAssert.AreEqual(expectedDurationList, actualDurationList);
     }
 
-    private void SetupBalancingAuthority(BalancingAuthority balancingAuthority, Location location)
+    private void MockBalancingAuthorityLocationMapping()
     {
-        this.LocationSource.Setup(r => r.ToGeopositionLocationAsync(location)).Returns(Task.FromResult(location));
-        var latitude = location.Latitude.ToString() ?? throw new ArgumentNullException(String.Format("Could not find location"));
-        var longitude = location.Longitude.ToString() ?? throw new ArgumentNullException(String.Format("Could not find location"));
+        this.LocationSource.Setup(r => r.ToGeopositionLocationAsync(this.DefaultLocation)).Returns(Task.FromResult(this.DefaultLocation));
+        var latitude = this.DefaultLocation.Latitude.ToString() ?? throw new ArgumentNullException(String.Format("Could not find location"));
+        var longitude = this.DefaultLocation.Longitude.ToString() ?? throw new ArgumentNullException(String.Format("Could not find location"));
 
         this.WattTimeClient.Setup(w => w.GetBalancingAuthorityAsync(latitude, longitude)
-        ).ReturnsAsync(() => balancingAuthority);
+        ).ReturnsAsync(() => this.DefaultBalancingAuthority);
+    }
 
+    private List<GridEmissionDataPoint> GenerateDataPoints(int?[] frequencies, float value = 10, DateTimeOffset startTime = default)
+    {
+        var dataPoints = new List<GridEmissionDataPoint>();
+        var pointTime = startTime == default ? this.DefaultDataStartTime : startTime;
+        foreach (var frequency in frequencies)
+        {
+            var dataPoint = new GridEmissionDataPoint()
+            {
+                BalancingAuthorityAbbreviation = this.DefaultBalancingAuthority.Abbreviation,
+                PointTime = pointTime,
+                Value = value,
+                Frequency = frequency
+            };
+            dataPoints.Add(dataPoint);
+            var nextDataPointDuration = frequency ?? 300;
+            pointTime += TimeSpan.FromSeconds(nextDataPointDuration);
+        };
+
+        return dataPoints;
     }
 }
 #pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.

--- a/src/CarbonAware.DataSources/CarbonAware.DataSources.WattTime/test/WattTimeDataSourceTests.cs
+++ b/src/CarbonAware.DataSources/CarbonAware.DataSources.WattTime/test/WattTimeDataSourceTests.cs
@@ -298,8 +298,9 @@ public class WattTimeDataSourceTests
         ).ReturnsAsync(() => this.DefaultBalancingAuthority);
     }
 
-    private List<GridEmissionDataPoint> GenerateDataPoints(int numberOfDatapoints, float value = 10, DateTimeOffset startTime = default, int? frequency = 300)
+    private List<GridEmissionDataPoint> GenerateDataPoints(int numberOfDatapoints, float value = 10, DateTimeOffset startTime = default)
     {
+        var defaultFrequency = 300;
         var dataPoints = new List<GridEmissionDataPoint>();
         var pointTime = startTime == default ? this.DefaultDataStartTime : startTime;
         for (int i = 0; i < numberOfDatapoints; i++)
@@ -309,11 +310,10 @@ public class WattTimeDataSourceTests
                 BalancingAuthorityAbbreviation = this.DefaultBalancingAuthority.Abbreviation,
                 PointTime = pointTime,
                 Value = value,
-                Frequency = frequency
+                Frequency = defaultFrequency
             };
             dataPoints.Add(dataPoint);
-            var nextDataPointDuration = frequency ?? 300;
-            pointTime += TimeSpan.FromSeconds(nextDataPointDuration);
+            pointTime += TimeSpan.FromSeconds(defaultFrequency);
         };
 
         return dataPoints;

--- a/src/CarbonAware.DataSources/CarbonAware.DataSources.WattTime/test/WattTimeDataSourceTests.cs
+++ b/src/CarbonAware.DataSources/CarbonAware.DataSources.WattTime/test/WattTimeDataSourceTests.cs
@@ -68,7 +68,6 @@ public class WattTimeDataSourceTests
             It.IsAny<DateTimeOffset>())
         ).ReturnsAsync(() => emissionData);
 
-        //SetupBalancingAuthority(balancingAuthority, location);
         var result = await this.DataSource.GetCarbonIntensityAsync(new List<Location>() { this.DefaultLocation }, startDate, endDate);
 
         Assert.IsNotNull(result);
@@ -208,8 +207,6 @@ public class WattTimeDataSourceTests
         this.WattTimeClient.Setup(w => w.GetCurrentForecastAsync(this.DefaultBalancingAuthority)
             ).ReturnsAsync(() => forecast);
 
-        //SetupBalancingAuthority(balancingAuthority, location);
-
         Assert.ThrowsAsync<WattTimeClientException>(async () => await this.DataSource.GetCurrentCarbonIntensityForecastAsync(this.DefaultLocation));
     }
 
@@ -229,7 +226,6 @@ public class WattTimeDataSourceTests
             ForecastData = emissionData
         };
 
-        //SetupBalancingAuthority(balancingAuthority, location);
         this.WattTimeClient.Setup(w => w.GetForecastOnDateAsync(this.DefaultBalancingAuthority, expectedAt)
                 ).ReturnsAsync(() => forecast);
 
@@ -301,11 +297,11 @@ public class WattTimeDataSourceTests
         ).ReturnsAsync(() => this.DefaultBalancingAuthority);
     }
 
-    private List<GridEmissionDataPoint> GenerateDataPoints(int numberOfDatapoints, float value = 10, DateTimeOffset startTime = default, int? frequency =300)
+    private List<GridEmissionDataPoint> GenerateDataPoints(int numberOfDatapoints, float value = 10, DateTimeOffset startTime = default, int? frequency = 300)
     {
         var dataPoints = new List<GridEmissionDataPoint>();
         var pointTime = startTime == default ? this.DefaultDataStartTime : startTime;
-        for(int i = 0; i < numberOfDatapoints; i++)
+        for (int i = 0; i < numberOfDatapoints; i++)
         {
             var dataPoint = new GridEmissionDataPoint()
             {
@@ -321,21 +317,5 @@ public class WattTimeDataSourceTests
 
         return dataPoints;
     }
-     /*   foreach (var frequency in frequencies)
-        {
-            var dataPoint = new GridEmissionDataPoint()
-            {
-                BalancingAuthorityAbbreviation = this.DefaultBalancingAuthority.Abbreviation,
-                PointTime = pointTime,
-                Value = value,
-                Frequency = frequency
-            };
-            dataPoints.Add(dataPoint);
-            var nextDataPointDuration = frequency ?? 300;
-            pointTime += TimeSpan.FromSeconds(nextDataPointDuration);
-        };
-
-        return dataPoints;
-    }*/
 }
 #pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.

--- a/src/CarbonAware.DataSources/CarbonAware.DataSources.WattTime/test/WattTimeDataSourceTests.cs
+++ b/src/CarbonAware.DataSources/CarbonAware.DataSources.WattTime/test/WattTimeDataSourceTests.cs
@@ -56,7 +56,7 @@ public class WattTimeDataSourceTests
     public async Task GetCarbonIntensity_ReturnsResultsWhenRecordsFound()
     {
         var startDate = this.DefaultDataStartTime;
-        var endDate = startDate.AddMinutes(1);
+        var endDate = new DateTimeOffset(2022, 4, 18, 12, 33, 42, TimeSpan.FromHours(-6));
         var lbsPerMwhEmissions = 10;
         var gPerKwhEmissions = this.DataSource.ConvertMoerToGramsPerKilowattHour(lbsPerMwhEmissions);
 
@@ -86,7 +86,7 @@ public class WattTimeDataSourceTests
     public async Task GetCarbonIntensity_ReturnsEmptyListWhenNoRecordsFound()
     {
         var startDate = new DateTimeOffset(2022, 4, 18, 12, 32, 42, TimeSpan.FromHours(-6));
-        var endDate = startDate.AddMinutes(1);
+        var endDate = new DateTimeOffset(2022, 4, 18, 12, 33, 42, TimeSpan.FromHours(-6));
 
         this.WattTimeClient.Setup(w => w.GetDataAsync(
             this.DefaultBalancingAuthority,
@@ -104,7 +104,7 @@ public class WattTimeDataSourceTests
     public void GetCarbonIntensity_ThrowsWhenRegionNotFound()
     {
         var startDate = new DateTimeOffset(2022, 4, 18, 12, 32, 42, TimeSpan.FromHours(-6));
-        var endDate = startDate.AddMinutes(1);
+        var endDate = new DateTimeOffset(2022, 4, 18, 12, 33, 42, TimeSpan.FromHours(-6));
 
         this.LocationSource.Setup(l => l.ToGeopositionLocationAsync(this.DefaultLocation)).Throws<LocationConversionException>();
 
@@ -117,7 +117,7 @@ public class WattTimeDataSourceTests
     {
         // Arrange
         var startDate = this.DefaultDataStartTime;
-        var endDate = startDate.AddMinutes(1);
+        var endDate = new DateTimeOffset(2022, 4, 18, 12, 33, 42, TimeSpan.FromHours(-6));
         var generatedAt = new DateTimeOffset(2022, 4, 18, 12, 30, 00, TimeSpan.FromHours(-6));
         var lbsPerMwhEmissions = 10;
         var gPerKwhEmissions = this.DataSource.ConvertMoerToGramsPerKilowattHour(lbsPerMwhEmissions);
@@ -181,7 +181,7 @@ public class WattTimeDataSourceTests
     }
 
     [Test]
-    public void GetCarbonIntensityForecastAsync_ThrowsWhenNoForecastFoundForRequestedTime()
+    public void GetCarbonIntensityForecastAsync_ThrowsWhenNoForecastFoundForReuqestedTime()
     {
         var generatedAt = new DateTimeOffset();
 
@@ -259,12 +259,11 @@ public class WattTimeDataSourceTests
     [TestCase(new double[] { 0 }, null, TestName = "GetCarbonIntensity - for less than 2 data points, frequency is null for one data point ")]
     [TestCase(new double[] { 300, 300 }, null, null, TestName = "GetCarbonIntensity - for multiple data points, frequency is null for all data points")]
     [TestCase(new double[] { 500 }, 500, TestName = "GetCarbonIntensity - frequency is not null")]
-    [TestCase(new double[] { }, TestName = "GetCarbonIntensity - for zero data points, returns empty enumerable")]
     public async Task GetCarbonIntensity_CalculatesDurationBasedOnFrequency(double[] durationValues, params int?[] frequencyValues)
     {
         // Arrange
         var startDate = this.DefaultDataStartTime;
-        var endDate = startDate.AddMinutes(10);
+        var endDate = new DateTimeOffset(2022, 4, 18, 12, 50, 00, TimeSpan.FromHours(-6));
         var emissionData = GenerateDataPoints(frequencyValues.Length);
         for( int i = 0; i < frequencyValues.Length; i++)
         {
@@ -291,10 +290,10 @@ public class WattTimeDataSourceTests
     private void MockBalancingAuthorityLocationMapping()
     {
         this.LocationSource.Setup(r => r.ToGeopositionLocationAsync(this.DefaultLocation)).Returns(Task.FromResult(this.DefaultLocation));
-        var latitude = this.DefaultLocation.Latitude.ToString();
-        var longitude = this.DefaultLocation.Longitude.ToString();
+        var latitude = this.DefaultLocation.Latitude.ToString() ?? throw new ArgumentNullException(String.Format("Could not find location"));
+        var longitude = this.DefaultLocation.Longitude.ToString() ?? throw new ArgumentNullException(String.Format("Could not find location"));
 
-        this.WattTimeClient.Setup(w => w.GetBalancingAuthorityAsync(latitude!, longitude!)
+        this.WattTimeClient.Setup(w => w.GetBalancingAuthorityAsync(latitude, longitude)
         ).ReturnsAsync(() => this.DefaultBalancingAuthority);
     }
 

--- a/src/CarbonAware.DataSources/CarbonAware.DataSources.WattTime/test/WattTimeDataSourceTests.cs
+++ b/src/CarbonAware.DataSources/CarbonAware.DataSources.WattTime/test/WattTimeDataSourceTests.cs
@@ -60,7 +60,7 @@ public class WattTimeDataSourceTests
         var lbsPerMwhEmissions = 10;
         var gPerKwhEmissions = this.DataSource.ConvertMoerToGramsPerKilowattHour(lbsPerMwhEmissions);
 
-        var emissionData = GenerateDataPoints(new int?[1], lbsPerMwhEmissions);
+        var emissionData = GenerateDataPoints(1, value: lbsPerMwhEmissions);
 
         this.WattTimeClient.Setup(w => w.GetDataAsync(
             this.DefaultBalancingAuthority,
@@ -124,7 +124,7 @@ public class WattTimeDataSourceTests
         var gPerKwhEmissions = this.DataSource.ConvertMoerToGramsPerKilowattHour(lbsPerMwhEmissions);
         var expectedDuration = TimeSpan.FromMinutes(5);
 
-        var emissionData = GenerateDataPoints(new int?[2], lbsPerMwhEmissions);
+        var emissionData = GenerateDataPoints(2, value: lbsPerMwhEmissions);
         var forecast = new Forecast()
         {
             GeneratedAt = generatedAt,
@@ -197,7 +197,7 @@ public class WattTimeDataSourceTests
     public void GetCurrentCarbonIntensityForecastAsync_ThrowsWhenTooFewDatapointsReturned(int numDataPoints)
     {
         // Arrange
-        var emissionData = GenerateDataPoints(new int?[numDataPoints]);
+        var emissionData = GenerateDataPoints(numDataPoints);
 
         var forecast = new Forecast()
         {
@@ -222,7 +222,7 @@ public class WattTimeDataSourceTests
         var requestedAt = DateTimeOffset.Parse(requested);
         var expectedAt = DateTimeOffset.Parse(expected);
 
-        var emissionData = GenerateDataPoints(new int?[2], startTime: requestedAt);
+        var emissionData = GenerateDataPoints(2, startTime: requestedAt);
         var forecast = new Forecast()
         {
             GeneratedAt = expectedAt,
@@ -268,7 +268,12 @@ public class WattTimeDataSourceTests
         // Arrange
         var startDate = this.DefaultDataStartTime;
         var endDate = new DateTimeOffset(2022, 4, 18, 12, 50, 00, TimeSpan.FromHours(-6));
-        var emissionData = GenerateDataPoints(frequencyValues);
+        var emissionData = GenerateDataPoints(frequencyValues.Length);
+        for( int i = 0; i < frequencyValues.Length; i++)
+        {
+            emissionData[i].Frequency = frequencyValues[i];
+        }
+        
         List<double> expectedDurationList = durationValues.ToList<double>();
 
         this.WattTimeClient.Setup(w => w.GetDataAsync(
@@ -296,11 +301,11 @@ public class WattTimeDataSourceTests
         ).ReturnsAsync(() => this.DefaultBalancingAuthority);
     }
 
-    private List<GridEmissionDataPoint> GenerateDataPoints(int?[] frequencies, float value = 10, DateTimeOffset startTime = default)
+    private List<GridEmissionDataPoint> GenerateDataPoints(int numberOfDatapoints, float value = 10, DateTimeOffset startTime = default, int? frequency =300)
     {
         var dataPoints = new List<GridEmissionDataPoint>();
         var pointTime = startTime == default ? this.DefaultDataStartTime : startTime;
-        foreach (var frequency in frequencies)
+        for(int i = 0; i < numberOfDatapoints; i++)
         {
             var dataPoint = new GridEmissionDataPoint()
             {
@@ -316,5 +321,21 @@ public class WattTimeDataSourceTests
 
         return dataPoints;
     }
+     /*   foreach (var frequency in frequencies)
+        {
+            var dataPoint = new GridEmissionDataPoint()
+            {
+                BalancingAuthorityAbbreviation = this.DefaultBalancingAuthority.Abbreviation,
+                PointTime = pointTime,
+                Value = value,
+                Frequency = frequency
+            };
+            dataPoints.Add(dataPoint);
+            var nextDataPointDuration = frequency ?? 300;
+            pointTime += TimeSpan.FromSeconds(nextDataPointDuration);
+        };
+
+        return dataPoints;
+    }*/
 }
 #pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.


### PR DESCRIPTION
Issue Number: 513

## Summary
Improve handling of null frequency values from WattTime



## Changes

- Use the distance between dataPoints as the default duration, rather than Zero
- New unit tests to reflect this behavior ([changes here](https://github.com/microsoft/carbon-aware-sdk/pull/117/files#diff-248efed1bc704787aa3472bf81b17048d1a99d755c9b73e107da03163071b99aR255-R288)).
- Refactor unit tests to reduce boilerplate.

## Checklist

- [x] Local Tests Passing?
- [x] CICD and Pipeline Tests Passing?
- [x] Added any new Tests? YES
- [x] Documentation Updates Made? NO
- [x] Are there any API Changes? NO
- [x] This is not a breaking change. If it is, please describe it below.
