### PR TITLE
540/cleanup single location calls

### DIFF
--- a/src/CarbonAware.Aggregators/src/CarbonAware/CarbonAwareAggregator.cs
+++ b/src/CarbonAware.Aggregators/src/CarbonAware/CarbonAwareAggregator.cs
@@ -33,7 +33,7 @@ public class CarbonAwareAggregator : ICarbonAwareAggregator
             DateTimeOffset end = GetOffsetOrDefault(props, CarbonAwareConstants.End, DateTimeOffset.Now.ToUniversalTime());
             DateTimeOffset start = GetOffsetOrDefault(props, CarbonAwareConstants.Start, end.AddDays(-7));
             _logger.LogInformation("Aggregator getting carbon intensity from data source");
-            return await this._dataSource.GetCarbonIntensityAsync(GetLocationsOrThrow(props), start, end);
+            return await this._dataSource.GetCarbonIntensityAsync(GetMutlipleLocationsOrThrow(props), start, end);
         }
     }
 
@@ -52,7 +52,7 @@ public class CarbonAwareAggregator : ICarbonAwareAggregator
             _logger.LogInformation("Aggregator getting carbon intensity forecast from data source");
 
             var forecasts = new List<EmissionsForecast>();
-            foreach (var location in GetLocationsOrThrow(props))
+            foreach (var location in GetMutlipleLocationsOrThrow(props))
             {
                 var forecast = await this._dataSource.GetCurrentCarbonIntensityForecastAsync(location);
                 var emissionsForecast = ProcessAndValidateForecast(forecast, props);
@@ -70,7 +70,7 @@ public class CarbonAwareAggregator : ICarbonAwareAggregator
         {
             var start = GetOffsetOrThrow(props, CarbonAwareConstants.Start);
             var end = GetOffsetOrThrow(props, CarbonAwareConstants.End);
-            var location = GetLocationOrThrow(props);
+            var location = GetSingleLocationOrThrow(props);
             ValidateDateInput(start, end);
             _logger.LogInformation("Aggregator getting average carbon intensity from data source");
             var emissionData = await this._dataSource.GetCarbonIntensityAsync(location, start, end);
@@ -86,10 +86,7 @@ public class CarbonAwareAggregator : ICarbonAwareAggregator
         EmissionsForecast forecast;
         using (var activity = Activity.StartActivity())
         {
-            ValidateForecastInput(props);
-
-            var location = (Location) props[CarbonAwareConstants.Location]!;
-            var forecastRequestedAt = GetOffsetOrDefault(props, CarbonAwareConstants.ForecastRequestedAt, default);
+            (var location, var forecastRequestedAt) = GetAndValidateForecastInput(props);
             _logger.LogDebug($"Aggregator getting carbon intensity forecast from data source for location {location} and requestedAt {forecastRequestedAt}");
 
             forecast = await this._dataSource.GetCarbonIntensityForecastAsync(location, forecastRequestedAt);
@@ -97,21 +94,27 @@ public class CarbonAwareAggregator : ICarbonAwareAggregator
             return emissionsForecast;
         }
     }
-    private void ValidateForecastInput(IDictionary props)
+    private (Location, DateTimeOffset) GetAndValidateForecastInput(IDictionary props)
     {
         var error = new ArgumentException("Invalid EmissionsForecast request");
-        if (props[CarbonAwareConstants.Location] == null)
-        {
-            error.Data["location"] = @"location parameter must be provided and be non empty";
+        Location location = new ();
+        DateTimeOffset requestedAt = new ();
+        try {
+            location = GetSingleLocationOrThrow(props);
+        } catch (ArgumentException e) {
+            error.Data["location"] = e.Message;
         }
-        if (props[CarbonAwareConstants.ForecastRequestedAt] == null)
-        {
-            error.Data["requestedAt"] = $"{CarbonAwareConstants.ForecastRequestedAt} field is required and was not provided.";
+        try {
+            requestedAt = GetOffsetOrThrow(props, CarbonAwareConstants.ForecastRequestedAt);
+        } 
+        catch (ArgumentException e) {
+            error.Data["requestedAt"] = e.Message;
         }
         if (error.Data.Count > 0)
         {
             throw error;
         }
+        return (location, requestedAt);
     }
 
     private EmissionsForecast ProcessAndValidateForecast(EmissionsForecast forecast, IDictionary props)
@@ -191,9 +194,9 @@ public class CarbonAwareAggregator : ICarbonAwareAggregator
         }
     }
 
-    private IEnumerable<Location> GetLocationsOrThrow(IDictionary props)
+    private IEnumerable<Location> GetMutlipleLocationsOrThrow(IDictionary props)
     {
-        if (props[CarbonAwareConstants.Locations] is IEnumerable<Location> locations)
+        if (props[CarbonAwareConstants.MultipleLocations] is IEnumerable<Location> locations)
         {
             return locations;
         }
@@ -202,12 +205,11 @@ public class CarbonAwareAggregator : ICarbonAwareAggregator
         throw ex;
     }
 
-    private Location GetLocationOrThrow(IDictionary props)
-    {
-        object? location = props[CarbonAwareConstants.Location];
-        if (location != null)
+    private Location GetSingleLocationOrThrow(IDictionary props)
+    {        
+        if (props[CarbonAwareConstants.SingleLocation] is Location location)
         {
-            return (Location) location;
+            return location;
         }
         Exception ex = new ArgumentException("location parameter must be provided");
         _logger.LogError("argument exception", ex);

--- a/src/CarbonAware.Aggregators/src/CarbonAware/ICarbonAwareAggregator.cs
+++ b/src/CarbonAware.Aggregators/src/CarbonAware/ICarbonAwareAggregator.cs
@@ -19,7 +19,6 @@ public interface ICarbonAwareAggregator : IAggregator
     /// <returns>The best EmissionsData object from the requested dataset or null if no dataset was found.</returns>
     Task<EmissionsData?> GetBestEmissionsDataAsync(IDictionary props);
 
-
     /// <summary>
     /// Get current forecasted emissions data.
     /// </summary>

--- a/src/CarbonAware.Aggregators/test/CarbonAwareAggregatorTests.cs
+++ b/src/CarbonAware.Aggregators/test/CarbonAwareAggregatorTests.cs
@@ -48,7 +48,7 @@ public class CarbonAwareAggregatorTests
 
         var props = new Dictionary<string, object?>()
         {
-            { CarbonAwareConstants.Locations, new List<Location>() { new Location() { RegionName = "westus" } } },
+            { CarbonAwareConstants.MultipleLocations, new List<Location>() { new Location() { RegionName = "westus" } } },
             { CarbonAwareConstants.Start, start },
             { CarbonAwareConstants.End, end },
         };
@@ -68,7 +68,7 @@ public class CarbonAwareAggregatorTests
         var emptyProps = new Dictionary<string, object>();
         var emptyLocationProps = new Dictionary<string, object>()
         {
-            { CarbonAwareConstants.Locations, new List<Location>() }
+            { CarbonAwareConstants.MultipleLocations, new List<Location>() }
         };
 
         Assert.ThrowsAsync<ArgumentException>(async () => await this.Aggregator.GetCurrentForecastDataAsync(emptyProps));
@@ -84,7 +84,7 @@ public class CarbonAwareAggregatorTests
             .ReturnsAsync(TestData.GetForecast("2022-01-01T00:00:00Z"));
         var props = new Dictionary<string, object>()
         {
-            { CarbonAwareConstants.Locations, new List<Location>() { new Location() { RegionName = "westus" } } },
+            { CarbonAwareConstants.MultipleLocations, new List<Location>() { new Location() { RegionName = "westus" } } },
             { CarbonAwareConstants.Start, start },
             { CarbonAwareConstants.End, end }
         };
@@ -103,7 +103,7 @@ public class CarbonAwareAggregatorTests
             .ReturnsAsync(TestData.GetForecast("2022-01-01T00:00:00Z"));
         var props = new Dictionary<string, object>()
         {
-            { CarbonAwareConstants.Locations, new List<Location>() { new Location() { RegionName = "westus" } } },
+            { CarbonAwareConstants.MultipleLocations, new List<Location>() { new Location() { RegionName = "westus" } } },
             { CarbonAwareConstants.Start, start },
             { CarbonAwareConstants.End, end }
         };
@@ -129,7 +129,7 @@ public class CarbonAwareAggregatorTests
         var locationName = "westus";
         var props = new Dictionary<string, object>()
         {
-            { CarbonAwareConstants.Locations, new List<Location>() { new Location() { RegionName = "westus" } } },
+            { CarbonAwareConstants.MultipleLocations, new List<Location>() { new Location() { RegionName = "westus" } } },
             { CarbonAwareConstants.Start, "2022-01-01T00:00:00Z" },
             { CarbonAwareConstants.End, "2022-01-01T00:15:00Z" },
             { CarbonAwareConstants.Duration, windowSize }
@@ -162,7 +162,7 @@ public class CarbonAwareAggregatorTests
         var locationName = "westus";
         var props = new Dictionary<string, object>()
         {
-            { CarbonAwareConstants.Locations, new List<Location>() { new Location() { RegionName = "westus" } } },
+            { CarbonAwareConstants.MultipleLocations, new List<Location>() { new Location() { RegionName = "westus" } } },
             { CarbonAwareConstants.Start, "2022-01-01T00:00:00Z" },
             { CarbonAwareConstants.End, "2022-01-01T00:20:00Z" },
         };
@@ -193,7 +193,7 @@ public class CarbonAwareAggregatorTests
             .ReturnsAsync(TestData.GetForecast("2022-01-01T00:00:00Z"));
         var props = new Dictionary<string, object?>()
         {
-            { CarbonAwareConstants.Locations, new List<Location>() { new Location() { RegionName = "westus" } } },
+            { CarbonAwareConstants.MultipleLocations, new List<Location>() { new Location() { RegionName = "westus" } } },
             { CarbonAwareConstants.Start, start },
             { CarbonAwareConstants.End, end }
         };
@@ -216,7 +216,7 @@ public class CarbonAwareAggregatorTests
     {
         var props = new Dictionary<string, object?>()
         {
-            { CarbonAwareConstants.Locations, new List<Location>() { new Location() { RegionName = "westus" }, new Location() { RegionName = "eastus" } } },
+            { CarbonAwareConstants.MultipleLocations, new List<Location>() { new Location() { RegionName = "westus" }, new Location() { RegionName = "eastus" } } },
             { CarbonAwareConstants.ForecastRequestedAt, new DateTimeOffset(2021,9,1,8,30,0, TimeSpan.Zero) }
         };
 
@@ -228,7 +228,7 @@ public class CarbonAwareAggregatorTests
     {
         var props = new Dictionary<string, object?>()
         {
-            { CarbonAwareConstants.Locations, new List<Location>() { new Location() { RegionName = "eastus" } } }
+            { CarbonAwareConstants.MultipleLocations, new List<Location>() { new Location() { RegionName = "eastus" } } }
         };
 
         Assert.ThrowsAsync<ArgumentException>(async () => await this.Aggregator.GetForecastDataAsync(props));
@@ -247,7 +247,7 @@ public class CarbonAwareAggregatorTests
             .ReturnsAsync(TestData.GetForecast("2022-01-01T00:00:00Z"));
         var props = new Dictionary<string, object?>()
         {
-            { CarbonAwareConstants.Locations, new List<Location>() { new Location() { RegionName = "westus" } } },
+            { CarbonAwareConstants.MultipleLocations, new List<Location>() { new Location() { RegionName = "westus" } } },
             { CarbonAwareConstants.Start, start },
             { CarbonAwareConstants.End, end },
             { CarbonAwareConstants.ForecastRequestedAt, requestedAt }
@@ -265,7 +265,7 @@ public class CarbonAwareAggregatorTests
             .ReturnsAsync(TestData.GetForecast("2022-01-01T00:00:00Z"));
         var props = new Dictionary<string, object>()
         {
-            { CarbonAwareConstants.Location, new Location() { RegionName = "westus" } },
+            { CarbonAwareConstants.SingleLocation, new Location() { RegionName = "westus" } },
             { CarbonAwareConstants.Start, start },
             { CarbonAwareConstants.End, end },
             { CarbonAwareConstants.ForecastRequestedAt, requestedAt }
@@ -288,7 +288,7 @@ public class CarbonAwareAggregatorTests
         const string reg = "westus";
         var props = new Dictionary<string, object>()
         {
-            { CarbonAwareConstants.Location, new Location() { RegionName = reg } },
+            { CarbonAwareConstants.SingleLocation, new Location() { RegionName = reg } },
             { CarbonAwareConstants.Start, DateTimeOffset.Parse("2022-01-01T00:00:00Z") },
             { CarbonAwareConstants.End,  DateTimeOffset.Parse("2022-01-01T00:20:00Z") },
             { CarbonAwareConstants.ForecastRequestedAt, requestedAt }
@@ -320,7 +320,7 @@ public class CarbonAwareAggregatorTests
 
         var props = new Dictionary<string, object?>()
         {
-            { CarbonAwareConstants.Location, location },
+            { CarbonAwareConstants.SingleLocation, location },
             { CarbonAwareConstants.Start, start },
             { CarbonAwareConstants.End, end }
         };
@@ -349,7 +349,7 @@ public class CarbonAwareAggregatorTests
 
         var props = new Dictionary<string, object?>()
         {
-            { CarbonAwareConstants.Locations, new List<Location>() { new Location() { RegionName = "westus" } } },
+            { CarbonAwareConstants.MultipleLocations, new List<Location>() { new Location() { RegionName = "westus" } } },
             { CarbonAwareConstants.Start, start },
             { CarbonAwareConstants.End, end }
         };
@@ -373,7 +373,7 @@ public class CarbonAwareAggregatorTests
 
         var props = new Dictionary<string, object?>()
         {
-            { CarbonAwareConstants.Location, location },
+            { CarbonAwareConstants.SingleLocation, location },
             { CarbonAwareConstants.Start, start },
             { CarbonAwareConstants.End, end }
         };

--- a/src/CarbonAware.Aggregators/test/CarbonAwareAggregatorTests.cs
+++ b/src/CarbonAware.Aggregators/test/CarbonAwareAggregatorTests.cs
@@ -325,7 +325,7 @@ public class CarbonAwareAggregatorTests
             { CarbonAwareConstants.End, end }
         };
 
-        this.CarbonIntensityDataSource.Setup(x => x.GetCarbonIntensityAsync(It.IsAny<IEnumerable<Location>>(),
+        this.CarbonIntensityDataSource.Setup(x => x.GetCarbonIntensityAsync(It.IsAny<Location>(),
             It.IsAny<DateTimeOffset>(), It.IsAny<DateTimeOffset>()))
             .ReturnsAsync(TestData.GetFilteredEmissionDataList(location.RegionName, startString, endString));
 

--- a/src/CarbonAware.Aggregators/test/CarbonAwareAggregatorTests.cs
+++ b/src/CarbonAware.Aggregators/test/CarbonAwareAggregatorTests.cs
@@ -265,7 +265,7 @@ public class CarbonAwareAggregatorTests
             .ReturnsAsync(TestData.GetForecast("2022-01-01T00:00:00Z"));
         var props = new Dictionary<string, object>()
         {
-            { CarbonAwareConstants.Locations, new List<Location>() { new Location() { RegionName = "westus" } } },
+            { CarbonAwareConstants.Location, new Location() { RegionName = "westus" } },
             { CarbonAwareConstants.Start, start },
             { CarbonAwareConstants.End, end },
             { CarbonAwareConstants.ForecastRequestedAt, requestedAt }
@@ -288,7 +288,7 @@ public class CarbonAwareAggregatorTests
         const string reg = "westus";
         var props = new Dictionary<string, object>()
         {
-            { CarbonAwareConstants.Locations, new List<Location>() { new Location() { RegionName = reg } } },
+            { CarbonAwareConstants.Location, new Location() { RegionName = reg } },
             { CarbonAwareConstants.Start, DateTimeOffset.Parse("2022-01-01T00:00:00Z") },
             { CarbonAwareConstants.End,  DateTimeOffset.Parse("2022-01-01T00:20:00Z") },
             { CarbonAwareConstants.ForecastRequestedAt, requestedAt }
@@ -314,17 +314,13 @@ public class CarbonAwareAggregatorTests
             RegionName = regionName
         };
 
-        List<Location> locations = new List<Location>() {
-          location
-        };
-
         DateTimeOffset start, end;
         DateTimeOffset.TryParse(startString, out start);
         DateTimeOffset.TryParse(endString, out end);
 
         var props = new Dictionary<string, object?>()
         {
-            { CarbonAwareConstants.Locations, locations },
+            { CarbonAwareConstants.Location, location },
             { CarbonAwareConstants.Start, start },
             { CarbonAwareConstants.End, end }
         };
@@ -337,7 +333,7 @@ public class CarbonAwareAggregatorTests
         var result = await this.Aggregator.CalculateAverageCarbonIntensityAsync(props);
 
         // Assert
-        this.CarbonIntensityDataSource.Verify(r => r.GetCarbonIntensityAsync(locations, start, end), Times.Once);
+        this.CarbonIntensityDataSource.Verify(r => r.GetCarbonIntensityAsync(location, start, end), Times.Once);
         return result;
     }
 
@@ -372,16 +368,12 @@ public class CarbonAwareAggregatorTests
             Longitude = (decimal)2.0
         };
 
-        List<Location> locations = new List<Location>() {
-          location
-        };
-
         var start = DateTimeOffset.Parse("2019-01-01", CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal);
         var end = DateTimeOffset.Parse("2019-01-02", CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal);
 
         var props = new Dictionary<string, object?>()
         {
-            { CarbonAwareConstants.Locations, locations },
+            { CarbonAwareConstants.Location, location },
             { CarbonAwareConstants.Start, start },
             { CarbonAwareConstants.End, end }
         };
@@ -390,6 +382,6 @@ public class CarbonAwareAggregatorTests
         await this.Aggregator.CalculateAverageCarbonIntensityAsync(props);
 
         // Assert
-        this.CarbonIntensityDataSource.Verify(r => r.GetCarbonIntensityAsync(locations, start, end), Times.Once);
+        this.CarbonIntensityDataSource.Verify(r => r.GetCarbonIntensityAsync(location, start, end), Times.Once);
     }
 }

--- a/src/CarbonAware.CLI/src/CarbonAwareCLI.cs
+++ b/src/CarbonAware.CLI/src/CarbonAwareCLI.cs
@@ -60,7 +60,7 @@ public class CarbonAwareCLI
     {
         IEnumerable<Location> locations = _state.Locations.Select(loc => new Location(){ RegionName = loc });
         var props = new Dictionary<string, object>() {
-            { CarbonAwareConstants.Locations, locations },
+            { CarbonAwareConstants.MultipleLocations, locations },
             { CarbonAwareConstants.Start, _state.Time },
             { CarbonAwareConstants.End, _state.ToTime },
             { CarbonAwareConstants.Best, true }

--- a/src/CarbonAware.DataSources/CarbonAware.DataSources.Json/src/JsonDataSource.cs
+++ b/src/CarbonAware.DataSources/CarbonAware.DataSources.Json/src/JsonDataSource.cs
@@ -37,6 +37,12 @@ public class JsonDataSource : ICarbonIntensityDataSource
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
+    public Task<IEnumerable<EmissionsData>> GetCarbonIntensityAsync(Location location, DateTimeOffset periodStartTime, DateTimeOffset periodEndTime)
+    {
+        return GetCarbonIntensityAsync(new List<Location>(){location}, periodStartTime, periodEndTime);
+        
+    }
+
     public Task<IEnumerable<EmissionsData>> GetCarbonIntensityAsync(IEnumerable<Location> locations, DateTimeOffset periodStartTime, DateTimeOffset periodEndTime)
     {
         _logger.LogInformation("JSON data source getting carbon intensity for locations {locations} for period {periodStartTime} to {periodEndTime}.", locations, periodStartTime, periodEndTime);

--- a/src/CarbonAware.DataSources/CarbonAware.DataSources.Json/src/JsonDataSource.cs
+++ b/src/CarbonAware.DataSources/CarbonAware.DataSources.Json/src/JsonDataSource.cs
@@ -37,12 +37,13 @@ public class JsonDataSource : ICarbonIntensityDataSource
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
+    /// <inheritdoc />
     public Task<IEnumerable<EmissionsData>> GetCarbonIntensityAsync(Location location, DateTimeOffset periodStartTime, DateTimeOffset periodEndTime)
     {
         return GetCarbonIntensityAsync(new List<Location>(){location}, periodStartTime, periodEndTime);
-        
     }
 
+    /// <inheritdoc />
     public Task<IEnumerable<EmissionsData>> GetCarbonIntensityAsync(IEnumerable<Location> locations, DateTimeOffset periodStartTime, DateTimeOffset periodEndTime)
     {
         _logger.LogInformation("JSON data source getting carbon intensity for locations {locations} for period {periodStartTime} to {periodEndTime}.", locations, periodStartTime, periodEndTime);
@@ -63,8 +64,7 @@ public class JsonDataSource : ICarbonIntensityDataSource
             _logger.LogDebug("Found {count} total emissions data records for locations {stringLocations} for period {periodStartTime} to {periodEndTime}.", emissionsData.Count(), stringLocations, periodStartTime, periodEndTime);
         }
 
-        return Task.FromResult(emissionsData);
-        
+        return Task.FromResult(emissionsData); 
     }
 
     public Task<EmissionsForecast> GetCurrentCarbonIntensityForecastAsync(Location location)

--- a/src/CarbonAware.DataSources/CarbonAware.DataSources.Json/src/JsonDataSource.cs
+++ b/src/CarbonAware.DataSources/CarbonAware.DataSources.Json/src/JsonDataSource.cs
@@ -40,7 +40,7 @@ public class JsonDataSource : ICarbonIntensityDataSource
     /// <inheritdoc />
     public Task<IEnumerable<EmissionsData>> GetCarbonIntensityAsync(Location location, DateTimeOffset periodStartTime, DateTimeOffset periodEndTime)
     {
-        return GetCarbonIntensityAsync(new List<Location>(){location}, periodStartTime, periodEndTime);
+        return GetCarbonIntensityAsync(new List<Location>() { location }, periodStartTime, periodEndTime);
     }
 
     /// <inheritdoc />

--- a/src/CarbonAware.DataSources/CarbonAware.DataSources.WattTime/src/WattTimeDataSource.cs
+++ b/src/CarbonAware.DataSources/CarbonAware.DataSources.WattTime/src/WattTimeDataSource.cs
@@ -51,19 +51,22 @@ public class WattTimeDataSource : ICarbonIntensityDataSource
     public async Task<IEnumerable<EmissionsData>> GetCarbonIntensityAsync(IEnumerable<Location> locations, DateTimeOffset periodStartTime, DateTimeOffset periodEndTime)
     {
         this.Logger.LogInformation("Getting carbon intensity for locations {locations} for period {periodStartTime} to {periodEndTime}.", locations, periodStartTime, periodEndTime);
-        List<EmissionsData> result = new ();
-        foreach (var location in locations)
+        using (var activity = Activity.StartActivity())
         {
-            IEnumerable<EmissionsData> interimResult = await GetCarbonIntensityAsync(location, periodStartTime, periodEndTime);
-            result.AddRange(interimResult);
+            List<EmissionsData> result = new ();
+            foreach (var location in locations)
+            {
+                IEnumerable<EmissionsData> interimResult = await GetCarbonIntensityAsync(location, periodStartTime, periodEndTime);
+                result.AddRange(interimResult);
+            }
+            return result;
         }
-        return result;
     }
 
+    /// <inheritdoc />
     public async Task<IEnumerable<EmissionsData>> GetCarbonIntensityAsync(Location location, DateTimeOffset periodStartTime, DateTimeOffset periodEndTime)
     {
         Logger.LogInformation($"Getting carbon intensity for location {location} for period {periodStartTime} to {periodEndTime}.");
-
         using (var activity = Activity.StartActivity())
         {
             var balancingAuthority = await this.GetBalancingAuthority(location, activity);

--- a/src/CarbonAware.WebApi/src/Controllers/CarbonAwareController.cs
+++ b/src/CarbonAware.WebApi/src/Controllers/CarbonAwareController.cs
@@ -48,8 +48,6 @@ public class CarbonAwareController : ControllerBase
                 { CarbonAwareConstants.Best, true }
             };
 
-            _logger.LogInformation("Calling aggregator GetBestEmissionsDataAsync with payload {@props}", props);
-
             var response = await _aggregator.GetBestEmissionsDataAsync(props);
             return response != null ? Ok(response) : NoContent();
         }
@@ -80,8 +78,6 @@ public class CarbonAwareController : ControllerBase
                 { CarbonAwareConstants.End, toTime},
                 { CarbonAwareConstants.Duration, durationMinutes },
             };
-
-            _logger.LogInformation("Calling aggregator GetEmissionsDataAsync with payload {@props}", props);
 
             var response = await _aggregator.GetEmissionsDataAsync(props);
             return response.Any() ? Ok(response) : NoContent();

--- a/src/CarbonAware.WebApi/src/Controllers/CarbonAwareController.cs
+++ b/src/CarbonAware.WebApi/src/Controllers/CarbonAwareController.cs
@@ -39,9 +39,9 @@ public class CarbonAwareController : ControllerBase
         using (var activity = Activity.StartActivity())
         {
             //The LocationType is hardcoded for now. Ideally this should be received from the request or configuration 
-            IEnumerable<Location> locationEnumerable = CreateLocationsFromQueryString(locations);
+            IEnumerable<Location> locationEnumerable = CreateMultipleLocationsFromStrings(locations);
             var props = new Dictionary<string, object?>() {
-                { CarbonAwareConstants.Locations, locationEnumerable },
+                { CarbonAwareConstants.MultipleLocations, locationEnumerable },
                 { CarbonAwareConstants.Start, time},
                 { CarbonAwareConstants.End, toTime },
                 { CarbonAwareConstants.Duration, durationMinutes },
@@ -73,9 +73,9 @@ public class CarbonAwareController : ControllerBase
     {
         using (var activity = Activity.StartActivity())
         {
-            IEnumerable<Location> locationEnumerable = CreateLocationsFromQueryString(locations);
+            IEnumerable<Location> locationEnumerable = CreateMultipleLocationsFromStrings(locations);
             var props = new Dictionary<string, object?>() {
-                { CarbonAwareConstants.Locations, locationEnumerable },
+                { CarbonAwareConstants.MultipleLocations, locationEnumerable },
                 { CarbonAwareConstants.Start, time },
                 { CarbonAwareConstants.End, toTime},
                 { CarbonAwareConstants.Duration, durationMinutes },
@@ -151,9 +151,9 @@ public class CarbonAwareController : ControllerBase
     {
         using (var activity = Activity.StartActivity())
         {
-            IEnumerable<Location> locationEnumerable = CreateLocationsFromQueryString(locations);
+            IEnumerable<Location> locationEnumerable = CreateMultipleLocationsFromStrings(locations);
             var props = new Dictionary<string, object?>() {
-                { CarbonAwareConstants.Locations, locationEnumerable },
+                { CarbonAwareConstants.MultipleLocations, locationEnumerable },
                 { CarbonAwareConstants.Start, dataStartAt },
                 { CarbonAwareConstants.End, dataEndAt },
                 { CarbonAwareConstants.Duration, windowSize },
@@ -195,7 +195,7 @@ public class CarbonAwareController : ControllerBase
             foreach (var forecastBatchDTO in requestedForecasts)
             {
                 var props = new Dictionary<string, object?>() {
-                    { CarbonAwareConstants.Location, CreateLocationFromQueryString(forecastBatchDTO.Location!) },
+                    { CarbonAwareConstants.SingleLocation, CreateSingleLocationFromString(forecastBatchDTO.Location!) },
                     { CarbonAwareConstants.Start, forecastBatchDTO.DataStartAt },
                     { CarbonAwareConstants.End, forecastBatchDTO.DataEndAt },
                     { CarbonAwareConstants.Duration, forecastBatchDTO.WindowSize },
@@ -233,7 +233,7 @@ public class CarbonAwareController : ControllerBase
         using (var activity = Activity.StartActivity())
         {
             var props = new Dictionary<string, object?>() {
-                { CarbonAwareConstants.Location, CreateLocationFromQueryString(location) },
+                { CarbonAwareConstants.SingleLocation, CreateSingleLocationFromString(location) },
                 { CarbonAwareConstants.Start, startTime },
                 { CarbonAwareConstants.End, endTime },
             };
@@ -277,7 +277,7 @@ public class CarbonAwareController : ControllerBase
             foreach (var carbonIntensityBatchDTO in requestedCarbonIntensities)
             {
                 var props = new Dictionary<string, object?>() {
-                    { CarbonAwareConstants.Location, CreateLocationFromQueryString(carbonIntensityBatchDTO.Location!) },
+                    { CarbonAwareConstants.SingleLocation, CreateSingleLocationFromString(carbonIntensityBatchDTO.Location!) },
                     { CarbonAwareConstants.Start, carbonIntensityBatchDTO.StartTime },
                     { CarbonAwareConstants.End, carbonIntensityBatchDTO.EndTime }
                 };
@@ -297,17 +297,17 @@ public class CarbonAwareController : ControllerBase
         }
     }
 
-    private IEnumerable<Location> CreateLocationsFromQueryString(string[] queryStringLocations)
+    private IEnumerable<Location> CreateMultipleLocationsFromStrings(string[] stringLocations)
     {
-        var locations = queryStringLocations
+        var locations = stringLocations
             .Where(location => !String.IsNullOrEmpty(location))
             .Select(location => new Location() { RegionName = location, LocationType = LocationType.CloudProvider });
         return locations.Any() ? locations : throw new ArgumentException("Required field: A value for 'location' must be provided.");
     }
 
-    private Location CreateLocationFromQueryString(string queryStringLocation)
+    private Location CreateSingleLocationFromString(string stringLocation)
     {
-        if (String.IsNullOrEmpty(queryStringLocation)) throw new ArgumentException("Required field: A value for 'location' must be provided.");
-        return new Location() { RegionName = queryStringLocation, LocationType = LocationType.CloudProvider };
+        if (String.IsNullOrEmpty(stringLocation)) throw new ArgumentException("Required field: A value for 'location' must be provided.");
+        return new Location() { RegionName = stringLocation, LocationType = LocationType.CloudProvider };
     }
 }

--- a/src/CarbonAware.WebApi/src/Controllers/CarbonAwareController.cs
+++ b/src/CarbonAware.WebApi/src/Controllers/CarbonAwareController.cs
@@ -252,7 +252,6 @@ public class CarbonAwareController : ControllerBase
         }
     }
 
-
     /// <summary>
     /// Given an array of request objects, each with their own location and time boundaries, calculate the average carbon intensity for that location and time period 
     /// and return an array of carbon intensity objects.

--- a/src/CarbonAware.WebApi/src/Controllers/SciScoreController.cs
+++ b/src/CarbonAware.WebApi/src/Controllers/SciScoreController.cs
@@ -67,11 +67,11 @@ public class SciScoreController : ControllerBase
         {
             _logger.LogDebug("calling to aggregator to calculate the average carbon intensity with input: {input}", input);
 
-            IEnumerable<Location> locationEnumerable = new List<Location>(){ GetLocation(input.Location) };
+            Location location = GetLocation(input.Location);
             (DateTimeOffset start, DateTimeOffset end) = SciScoreAggregator.ParseTimeInterval(input.TimeInterval);
 
             var props = new Dictionary<string, object?>() {
-                { CarbonAwareConstants.MultipleLocations, locationEnumerable },
+                { CarbonAwareConstants.SingleLocation, location },
                 { CarbonAwareConstants.Start, start },
                 { CarbonAwareConstants.End, end },
             };

--- a/src/CarbonAware.WebApi/src/Controllers/SciScoreController.cs
+++ b/src/CarbonAware.WebApi/src/Controllers/SciScoreController.cs
@@ -71,7 +71,7 @@ public class SciScoreController : ControllerBase
             (DateTimeOffset start, DateTimeOffset end) = SciScoreAggregator.ParseTimeInterval(input.TimeInterval);
 
             var props = new Dictionary<string, object?>() {
-                { CarbonAwareConstants.Locations, locationEnumerable },
+                { CarbonAwareConstants.MultipleLocations, locationEnumerable },
                 { CarbonAwareConstants.Start, start },
                 { CarbonAwareConstants.End, end },
             };

--- a/src/CarbonAware/src/CarbonAwareConstants.cs
+++ b/src/CarbonAware/src/CarbonAwareConstants.cs
@@ -5,8 +5,8 @@
 /// </summary>
 public class CarbonAwareConstants
 {
-    public const string Locations = "locations";
-    public const string Location = "location";
+    public const string MultipleLocations = "locations";
+    public const string SingleLocation = "location";
     public const string Start = "start";
     public const string End = "end";
     public const string Duration = "duration";

--- a/src/CarbonAware/src/CarbonAwareConstants.cs
+++ b/src/CarbonAware/src/CarbonAwareConstants.cs
@@ -6,6 +6,7 @@
 public class CarbonAwareConstants
 {
     public const string Locations = "locations";
+    public const string Location = "location";
     public const string Start = "start";
     public const string End = "end";
     public const string Duration = "duration";

--- a/src/CarbonAware/src/Interfaces/ICarbonIntensityDataSource.cs
+++ b/src/CarbonAware/src/Interfaces/ICarbonIntensityDataSource.cs
@@ -16,7 +16,7 @@ public interface ICarbonIntensityDataSource
     double MinSamplingWindow { get; }
 
     /// <summary>
-    /// Gets the carbon intensity for locations and start and end time
+    /// Gets the carbon intensity for multiple locations for a given start and end time
     /// </summary>
     /// <param name="locations">The locations that should be used for getting emissions data.</param>
     /// <param name="periodStartTime">The start time of the period.</param>
@@ -24,8 +24,8 @@ public interface ICarbonIntensityDataSource
     /// <returns>A list of emissions data for the given time period.</returns>
     public Task<IEnumerable<EmissionsData>> GetCarbonIntensityAsync(IEnumerable<Location> locations, DateTimeOffset periodStartTime, DateTimeOffset periodEndTime);
 
-        /// <summary>
-    /// Gets the carbon intensity for a location and start and end time
+    /// <summary>
+    /// Gets the carbon intensity for a single location for a given start and end time
     /// </summary>
     /// <param name="location">The location that should be used for getting emissions data.</param>
     /// <param name="periodStartTime">The start time of the period.</param>

--- a/src/CarbonAware/src/Interfaces/ICarbonIntensityDataSource.cs
+++ b/src/CarbonAware/src/Interfaces/ICarbonIntensityDataSource.cs
@@ -16,13 +16,22 @@ public interface ICarbonIntensityDataSource
     double MinSamplingWindow { get; }
 
     /// <summary>
-    /// Gets the carbon intensity for a location and start and end time
+    /// Gets the carbon intensity for locations and start and end time
     /// </summary>
     /// <param name="locations">The locations that should be used for getting emissions data.</param>
     /// <param name="periodStartTime">The start time of the period.</param>
     /// <param name="periodEndTime">The end time of the period.</param>
     /// <returns>A list of emissions data for the given time period.</returns>
     public Task<IEnumerable<EmissionsData>> GetCarbonIntensityAsync(IEnumerable<Location> locations, DateTimeOffset periodStartTime, DateTimeOffset periodEndTime);
+
+        /// <summary>
+    /// Gets the carbon intensity for a location and start and end time
+    /// </summary>
+    /// <param name="location">The location that should be used for getting emissions data.</param>
+    /// <param name="periodStartTime">The start time of the period.</param>
+    /// <param name="periodEndTime">The end time of the period.</param>
+    /// <returns>A list of emissions data for the given time period.</returns>
+    public Task<IEnumerable<EmissionsData>> GetCarbonIntensityAsync(Location location, DateTimeOffset periodStartTime, DateTimeOffset periodEndTime);
 
     /// <summary>
     /// Gets the current forecasted carbon intensity for a location


### PR DESCRIPTION
Issue Number: 540

## Summary
Cleanup Controller APIs, Aggregator Methods, DataSource methods, that expect "a collection of 1 Location" 

## Changes

- Added new CarbonAwareConstant `SingleLocation` and renamed `Locations` to `MultipleLocations` for clarity
- Removed extra array wrapping in Controller and aggregator for location (wrapping a single location into an array so that we can later pull out the first element of that array in the aggregator/datasource)
- Added separate paths for single/multiple location calls
- Cleaned up error handling for checking the location property exists (in single vs. multiple case)

## Checklist

- [X] Local Tests Passing?
- [X] CICD and Pipeline Tests Passing?
- [ ] Added any new Tests?
- [ ] Documentation Updates Made?
- [ ] Are there any API Changes? If yes, please describe below.
- [X] This is not a breaking change. If it is, please describe it below.

## Are there API Changes?
No

## Is this a breaking change?
No

## Anything else?
Other comments, collaborators, etc.
This PR Closes Issue #
