### PR TITLE
Fix cli failure missing emissions json data source file

### DIFF
--- a/src/CarbonAware.CLI/src/CarbonAware.CLI.csproj
+++ b/src/CarbonAware.CLI/src/CarbonAware.CLI.csproj
@@ -59,7 +59,7 @@
     <Copy SourceFiles="@(DataFiles)" DestinationFolder="$(TargetDir)\data-sources\json\%(RecursiveDir)" SkipUnchangedFiles="true" />
   </Target>
 
-  <Target Name="CopyDataFilesForPublish" AfterTargets="AfterPublish">
+  <Target Name="CopyDataFilesForPublish" AfterTargets="Publish">
     <ItemGroup>
       <DataFiles Include="$(ProjectDir)..\..\data\data-files\**\*.*" />
     </ItemGroup>

--- a/src/CarbonAware.CLI/src/CarbonAware.CLI.csproj
+++ b/src/CarbonAware.CLI/src/CarbonAware.CLI.csproj
@@ -52,11 +52,19 @@
   </ItemGroup>
 
  <Target Name="CopyDataFiles" AfterTargets="Build">
-		<ItemGroup>
-			<DataFiles Include="$(ProjectDir)..\data\data-files\*.*" />
-		</ItemGroup>
+    <ItemGroup>
+      <DataFiles Include="$(ProjectDir)..\..\data\data-files\**\*.*" />
+    </ItemGroup>
 
-		<Copy SourceFiles="@(DataFiles)" DestinationFolder="$(TargetDir)\data-files\" SkipUnchangedFiles="true" />
-	</Target>
+    <Copy SourceFiles="@(DataFiles)" DestinationFolder="$(TargetDir)\data-sources\json\%(RecursiveDir)" SkipUnchangedFiles="true" />
+  </Target>
+
+  <Target Name="CopyDataFilesForPublish" AfterTargets="AfterPublish">
+    <ItemGroup>
+      <DataFiles Include="$(ProjectDir)..\..\data\data-files\**\*.*" />
+    </ItemGroup>
+
+    <Copy SourceFiles="@(DataFiles)" DestinationFolder="$(PublishDir)\data-sources\json\%(RecursiveDir)" SkipUnchangedFiles="true" />
+  </Target>
 	
 </Project>

--- a/src/CarbonAware.WebApi/src/CarbonAware.WebApi.csproj
+++ b/src/CarbonAware.WebApi/src/CarbonAware.WebApi.csproj
@@ -53,7 +53,7 @@
     <Copy SourceFiles="@(DataFiles)" DestinationFolder="$(TargetDir)\data-sources\json\%(RecursiveDir)" SkipUnchangedFiles="true" />
   </Target>
 
-  <Target Name="CopyDataFilesForPublish" AfterTargets="AfterPublish">
+  <Target Name="CopyDataFilesForPublish" AfterTargets="Publish">
     <ItemGroup>
       <DataFiles Include="$(ProjectDir)..\..\data\data-files\**\*.*" />
     </ItemGroup>


### PR DESCRIPTION
Issue Number: (618)

## Summary
Fix missing emissions data source file for JSON data source

## Changes

- Copy files from` data-files` to `data-sources/json` directory

Before fix:
```sh
dotnet run --project CarbonAware.CLI/src/CarbonAware.CLI.csproj emissions -l eastus
Could not find a part of the path '/workspaces/carbon-aware-sdk/src/CarbonAware.CLI/src/bin/Debug/net6.0/data-sources/json/test-data-azure-emissions.json'.
```

After fix:
```sh
dotnet run --project CarbonAware.CLI/src/CarbonAware.CLI.csproj emissions -l eastus
[{"Location":"eastus","Time":"2022-09-06T12:45:11+00:00","Rating":84,"Duration":"08:00:00"}
,....
{"Location":"eastus","Time":"2022-09-13T12:45:11+00:00","Rating":69,"Duration":"08:00:00"}]
```

## Checklist


## Are there API Changes?
N/A
## Is this a breaking change?
N/A

## Anything else?
Bug fix