### PR TITLE
615/json datasource error

### DIFF
--- a/src/CarbonAware.DataSources/CarbonAware.DataSources.Json/src/JsonDataSource.cs
+++ b/src/CarbonAware.DataSources/CarbonAware.DataSources.Json/src/JsonDataSource.cs
@@ -20,7 +20,7 @@ public class JsonDataSource : ICarbonIntensityDataSource
 
     public string Version => "0.0.1";
 
-    public double MinSamplingWindow => 1440;  // 24 hrs
+    public double MinSamplingWindow => 120;  // 2 hrs
 
     private List<EmissionsData>? _emissionsData;
 

--- a/src/CarbonAware.DataSources/CarbonAware.DataSources.Json/src/JsonDataSource.cs
+++ b/src/CarbonAware.DataSources/CarbonAware.DataSources.Json/src/JsonDataSource.cs
@@ -20,7 +20,7 @@ public class JsonDataSource : ICarbonIntensityDataSource
 
     public string Version => "0.0.1";
 
-    public double MinSamplingWindow => 120;  // 2 hrs
+    public double MinSamplingWindow => 1440;  // 24 hrs
 
     private List<EmissionsData>? _emissionsData;
 

--- a/src/CarbonAware.DataSources/CarbonAware.DataSources.Json/test/JsonDataSourceTests.cs
+++ b/src/CarbonAware.DataSources/CarbonAware.DataSources.Json/test/JsonDataSourceTests.cs
@@ -109,19 +109,15 @@ public class JsonDataSourceTests
         return new List<EmissionsData>() {
                 new EmissionsData {
                     Location = "eastus",
-                    Time = DateTime.Parse("2021-09-01T13:45:11+00:00")
-                },
-                new EmissionsData {
-                    Location = "eastus",
-                    Time = DateTime.Parse("2021-05-01T13:45:11+00:00")
+                    Time = DateTime.Parse("2021-09-01")
                 },
                 new EmissionsData {
                     Location = "westus",
-                    Time = DateTime.Parse("2021-12-01T13:45:11+00:00")
+                    Time = DateTime.Parse("2021-12-01")
                 },
                 new EmissionsData {
                     Location = "eastus",
-                    Time = DateTime.Parse("2022-02-01T13:45:11+00:00")
+                    Time = DateTime.Parse("2022-02-01")
                 },
                 new EmissionsData {
                     Location = "midwest",

--- a/src/CarbonAware.DataSources/CarbonAware.DataSources.Json/test/JsonDataSourceTests.cs
+++ b/src/CarbonAware.DataSources/CarbonAware.DataSources.Json/test/JsonDataSourceTests.cs
@@ -74,6 +74,24 @@ public class JsonDataSourceTests
 
     }
 
+    [Test]
+    public async Task GetCarbonIntensityAsync_TimeInterval()
+    {
+        var mockDataSource = SetupMockDataSource();
+
+        var location = new Location() { RegionName = "midwest" };
+        IEnumerable<Location> locations = new List<Location>() { location };
+        var start = DateTimeOffset.Parse("2021-05-01T14:45:11+00:00");
+        var end = DateTimeOffset.Parse("2021-05-01T16:45:11+00:00");
+        var dataSource = mockDataSource.Object;
+        var result = await dataSource.GetCarbonIntensityAsync(locations, start, end);
+        Assert.AreEqual(2, result.Count());
+
+        foreach (var r in result)
+        {
+            Assert.IsTrue(locations.Where(loc => loc.RegionName == r.Location).Any());
+        }
+    }
     private Mock<JsonDataSource> SetupMockDataSource() {
         var logger = Mock.Of<ILogger<JsonDataSource>>();
         var monitor = Mock.Of<IOptionsMonitor<JsonDataSourceConfiguration>>();
@@ -91,19 +109,31 @@ public class JsonDataSourceTests
         return new List<EmissionsData>() {
                 new EmissionsData {
                     Location = "eastus",
-                    Time = DateTime.Parse("2021-09-01")
-                },
-                new EmissionsData {
-                    Location = "westus",
-                    Time = DateTime.Parse("2021-12-01")
+                    Time = DateTime.Parse("2021-09-01T13:45:11+00:00")
                 },
                 new EmissionsData {
                     Location = "eastus",
-                    Time = DateTime.Parse("2022-02-01")
+                    Time = DateTime.Parse("2021-05-01T13:45:11+00:00")
+                },
+                new EmissionsData {
+                    Location = "westus",
+                    Time = DateTime.Parse("2021-12-01T13:45:11+00:00")
+                },
+                new EmissionsData {
+                    Location = "eastus",
+                    Time = DateTime.Parse("2022-02-01T13:45:11+00:00")
                 },
                 new EmissionsData {
                     Location = "midwest",
-                    Time = DateTime.Parse("2021-05-01")
+                    Time = DateTime.Parse("2021-05-01T07:45:11+00:00")
+                },
+                new EmissionsData {
+                    Location = "midwest",
+                    Time = DateTime.Parse("2021-05-01T14:45:11+00:00")
+                },
+                new EmissionsData {
+                    Location = "midwest",
+                    Time = DateTime.Parse("2021-05-01T13:45:11+00:00")
                 }
             };
     }

--- a/src/CarbonAware.DataSources/CarbonAware.DataSources.Json/test/JsonDataSourceTests.cs
+++ b/src/CarbonAware.DataSources/CarbonAware.DataSources.Json/test/JsonDataSourceTests.cs
@@ -75,7 +75,7 @@ public class JsonDataSourceTests
     }
 
     [Test]
-    public async Task GetCarbonIntensityAsync_TimeInterval()
+    public async Task GetCarbonIntensityAsync_ReturnsData_UsingSamplingWindow()
     {
         var mockDataSource = SetupMockDataSource();
 

--- a/src/CarbonAware.DataSources/CarbonAware.DataSources.Json/test/JsonDataSourceTests.cs
+++ b/src/CarbonAware.DataSources/CarbonAware.DataSources.Json/test/JsonDataSourceTests.cs
@@ -80,7 +80,7 @@ public class JsonDataSourceTests
         var mockDataSource = SetupMockDataSource();
 
         var location = new Location() { RegionName = "midwest" };
-        IEnumerable<Location> locations = new List<Location>() { location };
+        var locations = new List<Location>() { location };
         var start = DateTimeOffset.Parse("2022-09-07T12:45:11+00:00");
         var end = DateTimeOffset.Parse("2022-09-07T13:45:11+00:00");
         var dataSource = mockDataSource.Object;

--- a/src/CarbonAware.DataSources/CarbonAware.DataSources.Json/test/JsonDataSourceTests.cs
+++ b/src/CarbonAware.DataSources/CarbonAware.DataSources.Json/test/JsonDataSourceTests.cs
@@ -81,11 +81,11 @@ public class JsonDataSourceTests
 
         var location = new Location() { RegionName = "midwest" };
         IEnumerable<Location> locations = new List<Location>() { location };
-        var start = DateTimeOffset.Parse("2021-05-01T14:45:11+00:00");
-        var end = DateTimeOffset.Parse("2021-05-01T16:45:11+00:00");
+        var start = DateTimeOffset.Parse("2022-09-07T12:45:11+00:00");
+        var end = DateTimeOffset.Parse("2022-09-07T13:45:11+00:00");
         var dataSource = mockDataSource.Object;
         var result = await dataSource.GetCarbonIntensityAsync(locations, start, end);
-        Assert.AreEqual(2, result.Count());
+        Assert.AreEqual(1, result.Count());
 
         foreach (var r in result)
         {
@@ -121,15 +121,18 @@ public class JsonDataSourceTests
                 },
                 new EmissionsData {
                     Location = "midwest",
-                    Time = DateTime.Parse("2021-05-01T07:45:11+00:00")
+                    Time = DateTime.Parse("2022-09-07T04:45:11+00:00"),
+                    Duration = TimeSpan.FromHours(8)
                 },
                 new EmissionsData {
                     Location = "midwest",
-                    Time = DateTime.Parse("2021-05-01T14:45:11+00:00")
+                    Time = DateTime.Parse("2022-09-07T12:45:11+00:00"),
+                    Duration = TimeSpan.FromHours(8)
                 },
                 new EmissionsData {
                     Location = "midwest",
-                    Time = DateTime.Parse("2021-05-01T13:45:11+00:00")
+                    Time = DateTime.Parse("2022-09-07T20:45:11+00:00"),
+                    Duration = TimeSpan.FromHours(8)
                 }
             };
     }

--- a/src/CarbonAware.DataSources/CarbonAware.DataSources.Json/test/JsonDataSourceTests.cs
+++ b/src/CarbonAware.DataSources/CarbonAware.DataSources.Json/test/JsonDataSourceTests.cs
@@ -75,7 +75,7 @@ public class JsonDataSourceTests
     }
 
     [Test]
-    public async Task GetCarbonIntensityAsync_ReturnsData_UsingSamplingWindow()
+    public async Task GetCarbonIntensityAsync_ReturnsSingleDataPoint_WhenStartParamExactlyMatchesDataStart()
     {
         var mockDataSource = SetupMockDataSource();
 

--- a/src/CarbonAware/src/IntervalHelper.cs
+++ b/src/CarbonAware/src/IntervalHelper.cs
@@ -17,7 +17,7 @@ public static class IntervalHelper
     {
         if (duration != default)
         {   // constant duration
-            return expandedData.Where(d => (d.Time + duration) >= startTime && d.Time <= endTime);
+            return expandedData.Where(d => (d.Time + duration) > startTime && d.Time <= endTime);
         }
         return expandedData.Where(d => (d.Time + d.Duration) >= startTime && d.Time <= endTime);
     }


### PR DESCRIPTION
Issue Number: [615](https://dev.azure.com/ZakimCSE/UBS%20Carbon-Aware/_boards/board/t/UBS%20Carbon-Aware%20Team/Stories/?workitem=615)

## Summary
When using Json datasource, StartTime variable returns the wrong output 

## Changes

- List of comprehensive changes

## Checklist

- [ ] Local Tests Passing?
- [ ] CICD and Pipeline Tests Passing?
- [ ] Added any new Tests?
- [ ] Documentation Updates Made?
- [ ] Are there any API Changes? If yes, please describe below.
- [ ] This is not a breaking change. If it is, please describe it below.

## Are there API Changes?
If yes, what are the expected API Changes? Please link to an API-Comparison workflow with the API Diff.

## Is this a breaking change?
If yes, what workflow does this break? 

## Anything else?
Other comments, collaborators, etc.
This PR Closes Issue #
