### PR TITLE
161/datasource interface config

### DIFF
--- a/GettingStarted.md
+++ b/GettingStarted.md
@@ -35,7 +35,7 @@ Please note that configuration is hierarchical.  The last configuration source l
 When adding values via environment variables, we recommend that you use the double underscore form, rather than the colon form.  Colons won't work in non-windows environment.  For example:
 
 ```bash
-  CarbonAwareVars__CarbonIntensityDataSource="WattTime"
+  "DataSources__EmissionsDataSource="WattTime"
 ```
 
 Note that double underscores are used to represent dotted notation or child elements that you see in the JSON below.  For example, to set proxy information using environment variables, you'd do this:
@@ -61,7 +61,8 @@ Used to configure specific values that affect how the application gets data and 
 ```json
 {
     "carbonAwareVars": {
-        "carbonIntensityDataSource": "",
+        "ForecastDataSource": "WattTime",
+        "EmissionsDataSource": "JSON",
         "webApiRoutePrefix": "",
         "proxy": {
             "useProxy": false,
@@ -73,13 +74,13 @@ Used to configure specific values that affect how the application gets data and 
 }
 ```
 
-##### carbonIntensityDataSource
+##### DataSource
 
-Must be one of the following: `None, JSON, WattTime`.  
+Each data source interface is configured with an underlying datasource. 
+
+Must be one of the following: `JSON, WattTime`.  
 
 If set to `WattTime`, WattTime configuration must also be supplied.
-
-`None` is the default, and if this value is supplied, an exception will be thrown at startup.
 
 `JSON` will result in the data being loaded from a [json file](./src/CarbonAware.DataSources.Json/test-data-azure-emissions.json) compiled into the project.  You should not use these values in production, since they are static and don't represent carbon intensity accurately.
 

--- a/src/CarbonAware.CLI/test/integrationTests/IntegrationTestingBase.cs
+++ b/src/CarbonAware.CLI/test/integrationTests/IntegrationTestingBase.cs
@@ -18,7 +18,8 @@ public abstract class IntegrationTestingBase
 {
     private string _executableName = "caw";
     internal DataSourceType _dataSource;
-    internal string? _dataSourceEnv;
+    internal string? _emissionsDataSourceEnv;
+    internal string? _forecastDataSourceEnv;
     protected IDataSourceMocker _dataSourceMocker;
     protected TestConsole _console = new();
 
@@ -28,7 +29,8 @@ public abstract class IntegrationTestingBase
 #pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
     {
         _dataSource = dataSource;
-        _dataSourceEnv = Environment.GetEnvironmentVariable("CarbonAwareVars__CarbonIntensityDataSource");
+        _emissionsDataSourceEnv = Environment.GetEnvironmentVariable("CarbonAwareVars__EmissionsDataSource");
+        _forecastDataSourceEnv = Environment.GetEnvironmentVariable("CarbonAwareVars__ForecastDataSource");
     }
 
     protected async Task<int> InvokeCliAsync(string arguments)
@@ -90,13 +92,14 @@ public abstract class IntegrationTestingBase
         {
             case DataSourceType.JSON:
                 {
-                    Environment.SetEnvironmentVariable("CarbonAwareVars__CarbonIntensityDataSource", "JSON");
+                    Environment.SetEnvironmentVariable("CarbonAwareVars__EmissionsDataSource", "JSON");
                     _dataSourceMocker = new JsonDataSourceMocker();
                     break;
                 }
             case DataSourceType.WattTime:
                 {
-                    Environment.SetEnvironmentVariable("CarbonAwareVars__CarbonIntensityDataSource", "WattTime");
+                    Environment.SetEnvironmentVariable("CarbonAwareVars__EmissionsDataSource", "WattTime");
+                    Environment.SetEnvironmentVariable("CarbonAwareVars__ForecastDataSource", "WattTime");
                     _dataSourceMocker = new WattTimeDataSourceMocker();
                     break;
                 }
@@ -140,6 +143,7 @@ public abstract class IntegrationTestingBase
     public void TearDown()
     {
         _dataSourceMocker.Dispose();
-        Environment.SetEnvironmentVariable("CarbonAwareVars__CarbonIntensityDataSource", _dataSourceEnv);
+        Environment.SetEnvironmentVariable("CarbonAwareVars__EmissionsDataSource", _emissionsDataSourceEnv);
+        Environment.SetEnvironmentVariable("CarbonAwareVars__ForecastDataSource", _forecastDataSourceEnv);
     }
 }

--- a/src/CarbonAware.DataSources/CarbonAware.DataSources.Json/src/Configuration/ServiceCollectionExtensions.cs
+++ b/src/CarbonAware.DataSources/CarbonAware.DataSources.Json/src/Configuration/ServiceCollectionExtensions.cs
@@ -7,15 +7,13 @@ namespace CarbonAware.DataSources.Json.Configuration;
 
 public static class ServiceCollectionExtensions
 {
-    public static void AddJsonDataSourceService(this IServiceCollection services, IConfiguration configuration)
+    public static void AddJsonEmissionsDataSource(this IServiceCollection services, IConfiguration configuration)
     {
         // configuring dependency injection to have config.
         services.Configure<JsonDataSourceConfiguration>(c =>
         {
             configuration.GetSection(JsonDataSourceConfiguration.Key).Bind(c);
         });
-        services.TryAddSingleton<IForecastDataSource, JsonDataSource>();
         services.TryAddSingleton<IEmissionsDataSource, JsonDataSource>();
-
     }
 }

--- a/src/CarbonAware.DataSources/CarbonAware.DataSources.Json/src/JsonDataSource.cs
+++ b/src/CarbonAware.DataSources/CarbonAware.DataSources.Json/src/JsonDataSource.cs
@@ -10,7 +10,7 @@ namespace CarbonAware.DataSources.Json;
 /// <summary>
 /// Represents a JSON data source.
 /// </summary>
-public class JsonDataSource : IEmissionsDataSource, IForecastDataSource
+public class JsonDataSource : IEmissionsDataSource
 {
     public string Name => "JsonDataSource";
 
@@ -71,16 +71,6 @@ public class JsonDataSource : IEmissionsDataSource, IForecastDataSource
         }
 
         return emissionsData;
-    }
-
-    public Task<EmissionsForecast> GetCurrentCarbonIntensityForecastAsync(Location location)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<EmissionsForecast> GetCarbonIntensityForecastAsync(Location location, DateTimeOffset generatedAt)
-    {
-        throw new NotImplementedException();
     }
 
     private IEnumerable<EmissionsData> FilterByDateRange(IEnumerable<EmissionsData> data, DateTimeOffset startTime, DateTimeOffset endTime)

--- a/src/CarbonAware.DataSources/CarbonAware.DataSources.Json/test/JsonDataSourceTests.cs
+++ b/src/CarbonAware.DataSources/CarbonAware.DataSources.Json/test/JsonDataSourceTests.cs
@@ -65,16 +65,6 @@ public class JsonDataSourceTests
     }
 
     [Test]
-    public void GetCurrentCarbonIntensityForecastAsync_NotImplemented()
-    {
-        var mockDataSource = SetupMockDataSource();
-        var dataSource = mockDataSource.Object;
-        var location = new Location {RegionName = "paris"};
-        Assert.ThrowsAsync<NotImplementedException>(async () => await  dataSource.GetCurrentCarbonIntensityForecastAsync(location));
-
-    }
-
-    [Test]
     public async Task GetCarbonIntensityAsync_ReturnsSingleDataPoint_WhenStartParamExactlyMatchesDataStart()
     {
         var mockDataSource = SetupMockDataSource();

--- a/src/CarbonAware.DataSources/CarbonAware.DataSources.Registration/Configuration/ServiceCollectionExtensions.cs
+++ b/src/CarbonAware.DataSources/CarbonAware.DataSources.Registration/Configuration/ServiceCollectionExtensions.cs
@@ -1,4 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
+using CarbonAware;
+using CarbonAware.Interfaces;
 using CarbonAware.DataSources.Json.Configuration;
 using CarbonAware.DataSources.WattTime.Configuration;
 using Microsoft.Extensions.Configuration;
@@ -7,39 +9,69 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 namespace CarbonAware.DataSources.Configuration;
 public static class ServiceCollectionExtensions
 {
-    public static void AddDataSourceService(this IServiceCollection services, IConfiguration configuration)
+    public static IServiceCollection AddDataSourceService(this IServiceCollection services, IConfiguration configuration)
     {
         // find all the Classes in the Assembly that implements AddEmissionServices method,
         // and added them here with the specific implementation class.
-        var envVars = configuration.GetSection(CarbonAwareVariablesConfiguration.Key).Get<CarbonAwareVariablesConfiguration>();
-        var dataSourceType = GetDataSourceTypeFromValue(envVars?.CarbonIntensityDataSource);
+        var carbonAwareConfig = configuration.GetSection(CarbonAwareVariablesConfiguration.Key).Get<CarbonAwareVariablesConfiguration>();
+        var forecastDataSource = GetDataSourceTypeFromValue(carbonAwareConfig?.ForecastDataSource);
+        var emissionsDataSource = GetDataSourceTypeFromValue(carbonAwareConfig?.EmissionsDataSource);
 
-        switch (dataSourceType)
+        if (forecastDataSource == DataSourceType.None && emissionsDataSource == DataSourceType.None)
+        {
+            throw new ArgumentException("At least one data source must be specified in configuration");
+        }
+
+        switch (forecastDataSource)
         {
             case DataSourceType.JSON:
             {
-                    services.AddJsonDataSourceService(configuration);
-                    break;
+                throw new ArgumentException("JSON data source is not supported for forecast data");
             }
             case DataSourceType.WattTime:
             {
-                    services.AddWattTimeDataSourceService(configuration);
-                    break;
+                services.AddWattTimeForecastDataSource(configuration);
+                break;
             }
             case DataSourceType.None:
             {
-                throw new NotSupportedException($"DataSourceType {dataSourceType.ToString()} not supported");
+                services.TryAddSingleton<IForecastDataSource, NullForecastDataSource>();
+                break;
             }
         }
+
+        switch (emissionsDataSource)
+        {
+            case DataSourceType.JSON:
+            {
+                services.AddJsonEmissionsDataSource(configuration);
+                break;
+            }
+            case DataSourceType.WattTime:
+            {
+                services.AddWattTimeEmissionsDataSource(configuration);
+                break;
+            }
+            case DataSourceType.None:
+            {
+                services.TryAddSingleton<IEmissionsDataSource, NullEmissionsDataSource>();
+                break;
+            }
+        }
+
+        return services;
     }
+
     private static DataSourceType GetDataSourceTypeFromValue(string? srcVal)
     {
         DataSourceType result;
-        if (String.IsNullOrEmpty(srcVal) ||
-            !Enum.TryParse<DataSourceType>(srcVal, true, out result))
+        if (String.IsNullOrWhiteSpace(srcVal))
         {
-            // defaults to JSON in case env is empty, null or parsing fails
-            return DataSourceType.JSON;
+            result = DataSourceType.None;
+        }
+        else if (!Enum.TryParse<DataSourceType>(srcVal, true, out result))
+        {
+            throw new ArgumentException($"Unknown data source type: {srcVal}");
         }
         return result;
     }

--- a/src/CarbonAware.DataSources/CarbonAware.DataSources.WattTime/src/Configuration/ServiceCollectionExtensions.cs
+++ b/src/CarbonAware.DataSources/CarbonAware.DataSources.WattTime/src/Configuration/ServiceCollectionExtensions.cs
@@ -9,12 +9,19 @@ namespace CarbonAware.DataSources.WattTime.Configuration;
 
 public static class ServiceCollectionExtensions
 {
-    public static void AddWattTimeDataSourceService(this IServiceCollection services, IConfiguration? configuration)
+    public static void AddWattTimeForecastDataSource(this IServiceCollection services, IConfiguration? configuration)
+    {
+        _ = configuration ?? throw new ConfigurationException("WattTime configuration required.");
+        services.ConfigureWattTimeClient(configuration);
+        services.TryAddSingleton<IForecastDataSource, WattTimeDataSource>();
+        services.TryAddSingleton<ILocationSource, AzureLocationSource>();
+    }
+
+    public static void AddWattTimeEmissionsDataSource(this IServiceCollection services, IConfiguration? configuration)
     {
         _ = configuration ?? throw new ConfigurationException("WattTime configuration required.");
         services.ConfigureWattTimeClient(configuration);
         services.TryAddSingleton<IEmissionsDataSource, WattTimeDataSource>();
-        services.TryAddSingleton<IForecastDataSource, WattTimeDataSource>();
         services.TryAddSingleton<ILocationSource, AzureLocationSource>();
     }
 }

--- a/src/CarbonAware.WebApi/test/integrationTests/CarbonAwareControllerTests.cs
+++ b/src/CarbonAware.WebApi/test/integrationTests/CarbonAwareControllerTests.cs
@@ -85,21 +85,6 @@ public class CarbonAwareControllerTests : IntegrationTestingBase
     }
 
     [Test]
-    public async Task EmissionsForecastsCurrent_UnsupportedDataSources_ReturnsNotImplemented()
-    {
-        IgnoreTestForDataSource("data source does implement '/emissions/forecasts/current'.", DataSourceType.WattTime);
-
-        var queryStrings = new Dictionary<string, string>();
-        queryStrings["location"] = "fakeLocation";
-
-        var endpointURI = ConstructUriWithQueryString(currentForecastURI, queryStrings);
-
-        var result = await _client.GetAsync(endpointURI);
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.StatusCode, Is.EqualTo(HttpStatusCode.NotImplemented));
-    }
-
-    [Test]
     public async Task EmissionsForecastsCurrent_SupportedDataSources_ReturnsOk()
     {
         IgnoreTestForDataSource("data source does not implement '/emissions/forecasts/current'", DataSourceType.JSON);

--- a/src/CarbonAware.WebApi/test/integrationTests/IntegrationTestingBase.cs
+++ b/src/CarbonAware.WebApi/test/integrationTests/IntegrationTestingBase.cs
@@ -18,7 +18,8 @@ namespace CarbonAware.WebApi.IntegrationTests;
 public abstract class IntegrationTestingBase
 {
     internal DataSourceType _dataSource;
-    internal string? _dataSourceEnv;
+    internal string? _emissionsDataSourceEnv;
+    internal string? _forecastDataSourceEnv;
     internal WebApplicationFactory<Program> _factory;
     protected HttpClient _client;
     protected IDataSourceMocker _dataSourceMocker;
@@ -29,7 +30,8 @@ public abstract class IntegrationTestingBase
 #pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
     {
         _dataSource = dataSource;
-        _dataSourceEnv = null;
+        _emissionsDataSourceEnv = null;
+        _forecastDataSourceEnv = null;
         _factory = new WebApplicationFactory<Program>();
     }
 
@@ -72,7 +74,8 @@ public abstract class IntegrationTestingBase
     [OneTimeSetUp]
     public void Setup()
     {
-        _dataSourceEnv = Environment.GetEnvironmentVariable("CarbonAwareVars__CarbonIntensityDataSource");
+        _emissionsDataSourceEnv = Environment.GetEnvironmentVariable("CarbonAwareVars__EmissionsDataSource");
+        _forecastDataSourceEnv = Environment.GetEnvironmentVariable("CarbonAwareVars__ForecastDataSource");
 
         //Switch between different data sources as needed
         //Each datasource should have an accompanying DataSourceMocker that will perform setup activities
@@ -80,7 +83,7 @@ public abstract class IntegrationTestingBase
         {
             case DataSourceType.JSON:
                 {
-                    Environment.SetEnvironmentVariable("CarbonAwareVars__CarbonIntensityDataSource", "JSON");
+                    Environment.SetEnvironmentVariable("CarbonAwareVars__EmissionsDataSource", "JSON");
                     Environment.SetEnvironmentVariable("CarbonAwareVars__VerboseApi", "true");
                     Environment.SetEnvironmentVariable("JsonDataSourceConfiguration__DataFileLocation", "demo.json");
                     _dataSourceMocker = new JsonDataSourceMocker();
@@ -88,7 +91,8 @@ public abstract class IntegrationTestingBase
                 }
             case DataSourceType.WattTime:
                 {
-                    Environment.SetEnvironmentVariable("CarbonAwareVars__CarbonIntensityDataSource", "WattTime");
+                    Environment.SetEnvironmentVariable("CarbonAwareVars__EmissionsDataSource", "WattTime");
+                    Environment.SetEnvironmentVariable("CarbonAwareVars__ForecastDataSource", "WattTime");
                     _dataSourceMocker = new WattTimeDataSourceMocker();
                     break;
                 }
@@ -120,6 +124,7 @@ public abstract class IntegrationTestingBase
         _client.Dispose();
         _factory.Dispose();
         _dataSourceMocker.Dispose();
-        Environment.SetEnvironmentVariable("CarbonAwareVars__CarbonIntensityDataSource", _dataSourceEnv);
+        Environment.SetEnvironmentVariable("CarbonAwareVars__EmissionsDataSource", _emissionsDataSourceEnv);
+        Environment.SetEnvironmentVariable("CarbonAwareVars__ForecastDataSource", _forecastDataSourceEnv);
     }
 }

--- a/src/CarbonAware/src/CarbonAwareVariablesConfiguration.cs
+++ b/src/CarbonAware/src/CarbonAwareVariablesConfiguration.cs
@@ -18,9 +18,14 @@ public class CarbonAwareVariablesConfiguration
     public PathString WebApiRoutePrefix { get; set; }
 
     /// <summary>
-    /// Gets or sets the the carbon intensity data source to use.
+    /// Gets or sets the forecast data source to use.
     /// </summary>
-    public string CarbonIntensityDataSource { get; set; }
+    public string ForecastDataSource { get; set; }
+
+    /// <summary>
+    /// Gets or sets the emissions data source to use.
+    /// </summary>
+    public string EmissionsDataSource { get; set; }
 
     #nullable enable
     /// <summary>


### PR DESCRIPTION
> **Warning**
> Draft PR for visibility purposes only!
> If ADR-0007 Data Source Interfaces is approved this PR will be reopened into the GSF dev branch
> This PR relies on #168.  It is split for ease of review, since the config changes are atomic from the underlying refactor.

## Summary
Exposes the new interfaces from ADR-0007 Green-Software-Foundation/carbon-aware-sdk#147 to operators through new configuration values.

## Changes

- Rather than throwing an exception for forecasting methods, JSON data source no longer implements `IForecastDataSource`
- EmissionsDataSource and ForecastDataSource are independently configurable.
- Documention updated to reflect change.
- Introduces the [Null object pattern](https://en.wikipedia.org/wiki/Null_object_pattern) rather than using any particular data source by default
- Requires operators to configure at least one data source, but not both.