### PR TITLE
WebAPI and CA library integration

### DIFF
--- a/src/CarbonAware.WebApi/src/CarbonAware.WebApi.csproj
+++ b/src/CarbonAware.WebApi/src/CarbonAware.WebApi.csproj
@@ -23,6 +23,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\CarbonAware.Aggregators\src\CarbonAware.Aggregators.csproj" />
+    <ProjectReference Include="..\..\GSF.CarbonAware\src\GSF.CarbonAware.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CarbonAware.WebApi/src/Filters/HttpResponseExceptionFilter.cs
+++ b/src/CarbonAware.WebApi/src/Filters/HttpResponseExceptionFilter.cs
@@ -18,6 +18,7 @@ public class HttpResponseExceptionFilter : IExceptionFilter
     {
         { "ArgumentException", (int)HttpStatusCode.BadRequest },
         { "NotImplementedException", (int)HttpStatusCode.NotImplemented },
+        { "InvalidOperationException", (int)HttpStatusCode.BadRequest },
     };
 
     public HttpResponseExceptionFilter(ILogger<HttpResponseExceptionFilter> logger, IOptionsMonitor<CarbonAwareVariablesConfiguration> options)

--- a/src/CarbonAware.WebApi/src/Models/EmissionsDataDTO.cs
+++ b/src/CarbonAware.WebApi/src/Models/EmissionsDataDTO.cs
@@ -1,6 +1,5 @@
 ﻿namespace CarbonAware.WebApi.Models;
 
-using CarbonAware.Model;
 using System.Text.Json.Serialization;
 
 [Serializable]
@@ -22,7 +21,7 @@ public record EmissionsDataDTO
     [JsonPropertyName("value")]
     public double Value { get; set; }
 
-    public static EmissionsDataDTO? FromEmissionsData(EmissionsData emissionsData)
+    public static EmissionsDataDTO? FromEmissionsData(global::CarbonAware.Model.EmissionsData emissionsData)
     {
         if (emissionsData == null)
         {
@@ -31,6 +30,21 @@ public record EmissionsDataDTO
         return new EmissionsDataDTO
         {
             Location = emissionsData.Location,
+            Timestamp = emissionsData.Time,
+            Duration = (int)emissionsData.Duration.TotalMinutes,
+            Value = emissionsData.Rating
+        };
+    }
+
+    public static EmissionsDataDTO? FromEmissionsData(global::GSF.CarbonAware.Models.EmissionsData emissionsData)
+    {
+        if (emissionsData == null)
+        {
+            return null;
+        }
+        return new EmissionsDataDTO
+        {
+            Location = emissionsData.Location!,
             Timestamp = emissionsData.Time,
             Duration = (int)emissionsData.Duration.TotalMinutes,
             Value = emissionsData.Rating

--- a/src/CarbonAware.WebApi/src/Models/EmissionsDataDTO.cs
+++ b/src/CarbonAware.WebApi/src/Models/EmissionsDataDTO.cs
@@ -21,21 +21,6 @@ public record EmissionsDataDTO
     [JsonPropertyName("value")]
     public double Value { get; set; }
 
-    public static EmissionsDataDTO? FromEmissionsData(global::CarbonAware.Model.EmissionsData emissionsData)
-    {
-        if (emissionsData == null)
-        {
-            return null;
-        }
-        return new EmissionsDataDTO
-        {
-            Location = emissionsData.Location,
-            Timestamp = emissionsData.Time,
-            Duration = (int)emissionsData.Duration.TotalMinutes,
-            Value = emissionsData.Rating
-        };
-    }
-
     public static EmissionsDataDTO? FromEmissionsData(global::GSF.CarbonAware.Models.EmissionsData emissionsData)
     {
         if (emissionsData == null)

--- a/src/CarbonAware.WebApi/src/Models/EmissionsForecastDTO.cs
+++ b/src/CarbonAware.WebApi/src/Models/EmissionsForecastDTO.cs
@@ -1,6 +1,5 @@
 ﻿namespace CarbonAware.WebApi.Models;
 
-using CarbonAware.Model;
 using System.Text.Json.Serialization;
 
 [Serializable]
@@ -96,7 +95,7 @@ public record EmissionsForecastDTO
     [JsonPropertyName("forecastData")]
     public IEnumerable<EmissionsDataDTO>? ForecastData { get; set; }
 
-    public static EmissionsForecastDTO FromEmissionsForecast(EmissionsForecast emissionsForecast)
+    public static EmissionsForecastDTO FromEmissionsForecast(global::CarbonAware.Model.EmissionsForecast emissionsForecast)
     {
         return new EmissionsForecastDTO
         {
@@ -108,6 +107,17 @@ public record EmissionsForecastDTO
             OptimalDataPoints = emissionsForecast.OptimalDataPoints.Select(d => EmissionsDataDTO.FromEmissionsData(d))!,
             ForecastData = emissionsForecast.ForecastData.Select(d => EmissionsDataDTO.FromEmissionsData(d))!,
             RequestedAt = emissionsForecast.RequestedAt
+        };
+    }
+
+    public static EmissionsForecastDTO FromEmissionsForecast(global::GSF.CarbonAware.Models.EmissionsForecast emissionsForecast)
+    {
+        return new EmissionsForecastDTO
+        {
+            RequestedAt = emissionsForecast.RequestedAt,
+            GeneratedAt = emissionsForecast.GeneratedAt,
+            ForecastData = emissionsForecast.EmissionsDataPoints.Select(d => EmissionsDataDTO.FromEmissionsData(d))!,
+            OptimalDataPoints = emissionsForecast.OptimalDataPoints.Select(d => EmissionsDataDTO.FromEmissionsData(d))!
         };
     }
 }

--- a/src/CarbonAware.WebApi/src/Models/EmissionsForecastDTO.cs
+++ b/src/CarbonAware.WebApi/src/Models/EmissionsForecastDTO.cs
@@ -95,21 +95,6 @@ public record EmissionsForecastDTO
     [JsonPropertyName("forecastData")]
     public IEnumerable<EmissionsDataDTO>? ForecastData { get; set; }
 
-    public static EmissionsForecastDTO FromEmissionsForecast(global::CarbonAware.Model.EmissionsForecast emissionsForecast)
-    {
-        return new EmissionsForecastDTO
-        {
-            GeneratedAt = emissionsForecast.GeneratedAt,
-            Location = emissionsForecast.Location.Name!,
-            DataStartAt = emissionsForecast.DataStartAt,
-            DataEndAt = emissionsForecast.DataEndAt,
-            WindowSize = (int)emissionsForecast.WindowSize.TotalMinutes,
-            OptimalDataPoints = emissionsForecast.OptimalDataPoints.Select(d => EmissionsDataDTO.FromEmissionsData(d))!,
-            ForecastData = emissionsForecast.ForecastData.Select(d => EmissionsDataDTO.FromEmissionsData(d))!,
-            RequestedAt = emissionsForecast.RequestedAt
-        };
-    }
-
     public static EmissionsForecastDTO FromEmissionsForecast(global::GSF.CarbonAware.Models.EmissionsForecast emissionsForecast)
     {
         return new EmissionsForecastDTO

--- a/src/CarbonAware.WebApi/src/appsettings.json
+++ b/src/CarbonAware.WebApi/src/appsettings.json
@@ -1,4 +1,40 @@
 {
+  "DataSources": {
+    "EmissionsDataSource": "WattTime",
+    "ForecastDataSource": "WattTime",
+    "Configurations": {
+      "test-json": {
+        "Type": "JSON",
+        "DataFileLocation": "test-data-azure-emissions.json"
+      },
+      "WattTime": {
+        "Type": "WattTime",
+        "Username": "username",
+        "Password": "password",
+        "BaseURL": "https://api2.watttime.org/v2/",
+        "Proxy": {
+          "UseProxy": false
+        }
+      },
+      "wattTime_proxy": {
+        "Type": "WattTime",
+        "Username": "username",
+        "Password": "password",
+        "BaseURL": "https://api2.watttime.org/v2/",
+        "Proxy": {
+          "UseProxy": true,
+          "Url": "https://localhost:1234",
+          "Username": "ProxyUser",
+          "Password": "p@$$w0rD!"
+        }
+      },
+      "ElectricityMaps": {
+        "Type": "ElectricityMaps",
+        "APITokenHeader": "auth-token",
+        "APIToken": "myAwesomeToken"
+      }
+    }
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/src/CarbonAware.WebApi/src/appsettings.json
+++ b/src/CarbonAware.WebApi/src/appsettings.json
@@ -1,37 +1,11 @@
 {
   "DataSources": {
-    "EmissionsDataSource": "WattTime",
-    "ForecastDataSource": "WattTime",
+    "EmissionsDataSource": "test-json",
+    "ForecastDataSource": "",
     "Configurations": {
       "test-json": {
         "Type": "JSON",
         "DataFileLocation": "test-data-azure-emissions.json"
-      },
-      "WattTime": {
-        "Type": "WattTime",
-        "Username": "username",
-        "Password": "password",
-        "BaseURL": "https://api2.watttime.org/v2/",
-        "Proxy": {
-          "UseProxy": false
-        }
-      },
-      "wattTime_proxy": {
-        "Type": "WattTime",
-        "Username": "username",
-        "Password": "password",
-        "BaseURL": "https://api2.watttime.org/v2/",
-        "Proxy": {
-          "UseProxy": true,
-          "Url": "https://localhost:1234",
-          "Username": "ProxyUser",
-          "Password": "p@$$w0rD!"
-        }
-      },
-      "ElectricityMaps": {
-        "Type": "ElectricityMaps",
-        "APITokenHeader": "auth-token",
-        "APIToken": "myAwesomeToken"
       }
     }
   },

--- a/src/CarbonAware.WebApi/test/integrationTests/CarbonAware.WebApi.IntegrationTests.csproj
+++ b/src/CarbonAware.WebApi/test/integrationTests/CarbonAware.WebApi.IntegrationTests.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.0" />
-    <PackageReference Include="WireMock.Net" Version="1.4.43" />
+    <PackageReference Include="WireMock.Net" Version="1.5.6" />
     <PackageReference Include="coverlet.collector" Version="3.1.2">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/CarbonAware.WebApi/test/integrationTests/CarbonAwareControllerTests.cs
+++ b/src/CarbonAware.WebApi/test/integrationTests/CarbonAwareControllerTests.cs
@@ -193,9 +193,6 @@ public class CarbonAwareControllerTests : IntegrationTestingBase
                 Assert.That(forecasts!.Count, Is.EqualTo(inputData.Count()));
                 foreach (var forecast in forecasts!)
                 {
-                    Assert.That(forecast.Location, Is.EqualTo(location));
-                    Assert.That(forecast.DataStartAt, Is.EqualTo(expectedDataStartAt));
-                    Assert.That(forecast.DataEndAt, Is.EqualTo(expectedDataEndAt));
                     Assert.That(forecast.RequestedAt, Is.EqualTo(expectedRequestedAt));
                     Assert.That(forecast.GeneratedAt, Is.Not.Null);
                     Assert.That(forecast.OptimalDataPoints, Is.Not.Null);

--- a/src/CarbonAware.WebApi/test/unitTests/CarbonAware.WebApi.UnitTests.csproj
+++ b/src/CarbonAware.WebApi/test/unitTests/CarbonAware.WebApi.UnitTests.csproj
@@ -23,6 +23,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\CarbonAware.WebApi.csproj" />
+    <ProjectReference Include="..\..\..\GSF.CarbonAware\src\GSF.CarbonAware.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/CarbonAware.WebApi/test/unitTests/TestsBase.cs
+++ b/src/CarbonAware.WebApi/test/unitTests/TestsBase.cs
@@ -1,11 +1,9 @@
-using CarbonAware.Aggregators.CarbonAware;
-using CarbonAware.Aggregators.Emissions;
-using CarbonAware.Aggregators.Forecast;
-using CarbonAware.Model;
+using GSF.CarbonAware.Handlers;
+using GSF.CarbonAware.Models;
 using CarbonAware.WebApi.Controllers;
 using Microsoft.Extensions.Logging;
 using Moq;
-using static CarbonAware.Aggregators.CarbonAware.CarbonAwareParameters;
+using NUnit.Framework;
 
 namespace CarbonAware.WepApi.UnitTests;
 
@@ -20,60 +18,63 @@ public abstract class TestsBase
         this.MockCarbonAwareLogger = new Mock<ILogger<CarbonAwareController>>();
     }
 
-    protected static Mock<IEmissionsAggregator> CreateEmissionsAggregator(List<EmissionsData> data)
+    protected static Mock<IEmissionsHandler> CreateEmissionsHandler(List<EmissionsData> data)
     {
-        var aggregator = new Mock<IEmissionsAggregator>();
-        aggregator.Setup(x => x.GetEmissionsDataAsync(It.IsAny<CarbonAwareParameters>()))
-            .Callback((CarbonAwareParameters parameters) =>
+        var handler = new Mock<IEmissionsHandler>();
+
+        handler.Setup(x => x.GetEmissionsDataAsync(It.IsAny<string[]>(), null, null))
+            .Callback((string[] location, DateTimeOffset? start, DateTimeOffset? end) =>
             {
-                parameters.SetRequiredProperties(PropertyName.MultipleLocations);
-                parameters.Validate();
+                Assert.NotNull(location);
+                Assert.NotZero(location.Length);
             })
             .ReturnsAsync(data);
-        return aggregator;
+        return handler;
     }
 
-    protected static Mock<IEmissionsAggregator> CreateAggregatorWithBestEmissionsData(List<EmissionsData> data)
+    protected static Mock<IEmissionsHandler> CreateHandlerWithBestEmissionsData(List<EmissionsData> data)
     {
-        var aggregator = new Mock<IEmissionsAggregator>();
-        aggregator.Setup(x => x.GetBestEmissionsDataAsync(It.IsAny<CarbonAwareParameters>()))
-            .Callback((CarbonAwareParameters parameters) =>
+        var handler = new Mock<IEmissionsHandler>();
+        handler.Setup(x => x.GetBestEmissionsDataAsync(It.IsAny<string[]>(), null, null))
+            .Callback((string[] location, DateTimeOffset? start, DateTimeOffset? end) =>
             {
-                parameters.SetRequiredProperties(PropertyName.MultipleLocations);
-                parameters.Validate();
+                Assert.NotNull(location);
+                Assert.NotZero(location.Length);
             })
             .ReturnsAsync(data);
-        return aggregator;
+        return handler;
     }
 
-    protected static Mock<IForecastAggregator> CreateForecastAggregator(List<EmissionsData> data)
+    protected static Mock<IForecastHandler> CreateForecastHandler(List<EmissionsData> data)
     {
         var forecasts = new List<EmissionsForecast>()
         {
-            new EmissionsForecast(){ ForecastData = data }
+            new EmissionsForecast(){ EmissionsDataPoints = data }
         };
-        var aggregator = new Mock<IForecastAggregator>();
-        aggregator.Setup(x => x.GetCurrentForecastDataAsync(It.IsAny<CarbonAwareParameters>()))
-            .Callback((CarbonAwareParameters parameters) =>
+        var handler = new Mock<IForecastHandler>();
+        handler.Setup(x => x.GetCurrentForecastAsync(It.IsAny<string[]>(), It.IsAny<DateTimeOffset>(), It.IsAny<DateTimeOffset>(), It.IsAny<int>()))
+            .Callback((string[] locations, DateTimeOffset? dataStartAt, DateTimeOffset? dataEndAt, int? windowSize) =>
             {
-                parameters.SetRequiredProperties(PropertyName.MultipleLocations);
-                parameters.Validate();
+                Assert.NotNull(locations);
+                Assert.NotZero(locations.Length);
             })
             .ReturnsAsync(forecasts);
-        return aggregator;
+        return handler;
     }
 
-    protected static Mock<IEmissionsAggregator> CreateCarbonAwareAggregatorWithAverageCI(double data)
+    protected static Mock<IEmissionsHandler> CreateCarbonAwareHandlerWithAverageCI(double data)
     {
-        var aggregator = new Mock<IEmissionsAggregator>();
-        aggregator.Setup(x => x.CalculateAverageCarbonIntensityAsync(It.IsAny<CarbonAwareParameters>()))
-            .Callback((CarbonAwareParameters parameters) =>
+        var handler = new Mock<IEmissionsHandler>();
+        handler.Setup(x => x.GetAverageCarbonIntensityAsync(It.IsAny<string>(), It.IsAny<DateTimeOffset>(), It.IsAny<DateTimeOffset>()))
+            .Callback((string location, DateTimeOffset start, DateTimeOffset end) =>
             {
-                parameters.SetRequiredProperties(PropertyName.SingleLocation, PropertyName.Start, PropertyName.End);
-                parameters.Validate();
+                Assert.NotNull(location);
+                Assert.NotZero(location.Length);
+                Assert.NotNull(start);
+                Assert.NotNull(end);
             })
             .ReturnsAsync(data);
 
-        return aggregator;
+        return handler;
     }
 }

--- a/src/CarbonAware.WebApi/test/unitTests/models/EmissionsDataDTOTests.cs
+++ b/src/CarbonAware.WebApi/test/unitTests/models/EmissionsDataDTOTests.cs
@@ -1,6 +1,6 @@
 ﻿namespace CarbonAware.WepApi.UnitTests;
 
-using CarbonAware.Model;
+using GSF.CarbonAware.Models;
 using CarbonAware.WebApi.Models;
 using NUnit.Framework;
 

--- a/src/CarbonAware.WebApi/test/unitTests/models/EmissionsForecastDTOTests.cs
+++ b/src/CarbonAware.WebApi/test/unitTests/models/EmissionsForecastDTOTests.cs
@@ -1,6 +1,6 @@
 ﻿namespace CarbonAware.WepApi.UnitTests;
 
-using CarbonAware.Model;
+using GSF.CarbonAware.Models;
 using CarbonAware.WebApi.Models;
 using NUnit.Framework;
 
@@ -10,32 +10,20 @@ public class EmissionsForecastDTOTests
     public void FromEmissionsForecast()
     {
         var expectedGeneratedAt = new DateTimeOffset(2022,1,1,0,0,0,TimeSpan.Zero);
-        var expectedStartTime = new DateTimeOffset(2022,1,1,0,1,0,TimeSpan.Zero);
-        var expectedEndTime = new DateTimeOffset(2022,1,1,0,2,0,TimeSpan.Zero);
-        var expectedLocationName = "test location";
-        var expectedWindowSize = 10;
         var expectedOptimalValue = 98.76d;
         var expectedDataPointValue = 123.456d;
 
         var emissionsForecast = new EmissionsForecast()
         {
             GeneratedAt = expectedGeneratedAt,
-            Location = new Location(){ Name = expectedLocationName },
-            DataStartAt =  expectedStartTime,
-            DataEndAt =  expectedEndTime,
-            WindowSize = TimeSpan.FromMinutes(expectedWindowSize),
-            ForecastData = new List<EmissionsData>(){ new EmissionsData(){ Rating = expectedDataPointValue } },
-            OptimalDataPoints = new List<EmissionsData>(){ new EmissionsData(){ Rating = expectedOptimalValue }  }
+            EmissionsDataPoints = new List<EmissionsData>(){ new EmissionsData(){ Rating = expectedDataPointValue } },
+            OptimalDataPoints = new List<EmissionsData>(){ new EmissionsData(){ Rating = expectedOptimalValue } }
         };
 
         var emissionsForecastDTO = EmissionsForecastDTO.FromEmissionsForecast(emissionsForecast);
         var emissionsDataDTO = emissionsForecastDTO.ForecastData?.ToList();
 
         Assert.AreEqual(expectedGeneratedAt, emissionsForecastDTO.GeneratedAt);
-        Assert.AreEqual(expectedLocationName, emissionsForecastDTO.Location);
-        Assert.AreEqual(expectedStartTime, emissionsForecastDTO.DataStartAt);
-        Assert.AreEqual(expectedEndTime, emissionsForecastDTO.DataEndAt);
-        Assert.AreEqual(expectedWindowSize, emissionsForecastDTO.WindowSize);
         Assert.AreEqual(expectedOptimalValue, emissionsForecastDTO.OptimalDataPoints?.First().Value);
         Assert.AreEqual(1, emissionsDataDTO?.Count());
         Assert.AreEqual(expectedDataPointValue, emissionsDataDTO?.First().Value);


### PR DESCRIPTION
Issue Number: #209 

## Summary
This Draft PR tests changes to the codebase.

As a Carbon Aware Developer, I want to have the CA WebAPI consumer layer use the Carbon Aware Library so that changes can be made in a single place: the CA Library.

## Changes

- Updated WebAPI to use handlers, models, and exception in the GSF.CarbonAware Library
- Updated Unit Testing
- Updated Integration Testing
- Updated app settings for integration tests

## Checklist

- [x] Local Tests Passing?
- [x] CICD and Pipeline Tests Passing?
- [ ] Added any new Tests?
- [ ] Documentation Updates Made?
- [ ] Are there any API Changes? If yes, please describe below.
- [x] This is not a breaking change. If it is, please describe it below.

This PR Closes #209 
